### PR TITLE
feat: convert QuickView UI to Tailwind CSS + shadcn design system

### DIFF
--- a/quickview-tool/public/index.html
+++ b/quickview-tool/public/index.html
@@ -4,6 +4,58 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>QuickView - Rapid Prototyping Tool</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        border: 'hsl(var(--border))',
+                        input: 'hsl(var(--input))',
+                        ring: 'hsl(var(--ring))',
+                        background: 'hsl(var(--background))',
+                        foreground: 'hsl(var(--foreground))',
+                        primary: {
+                            DEFAULT: 'hsl(var(--primary))',
+                            foreground: 'hsl(var(--primary-foreground))',
+                        },
+                        secondary: {
+                            DEFAULT: 'hsl(var(--secondary))',
+                            foreground: 'hsl(var(--secondary-foreground))',
+                        },
+                        muted: {
+                            DEFAULT: 'hsl(var(--muted))',
+                            foreground: 'hsl(var(--muted-foreground))',
+                        },
+                        accent: {
+                            DEFAULT: 'hsl(var(--accent))',
+                            foreground: 'hsl(var(--accent-foreground))',
+                        },
+                        card: {
+                            DEFAULT: 'hsl(var(--card))',
+                            foreground: 'hsl(var(--card-foreground))',
+                        },
+                        destructive: {
+                            DEFAULT: 'hsl(var(--destructive))',
+                            foreground: 'hsl(var(--destructive-foreground))',
+                        },
+                    },
+                    borderRadius: {
+                        lg: 'var(--radius)',
+                        md: 'calc(var(--radius) - 2px)',
+                        sm: 'calc(var(--radius) - 4px)',
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', 'monospace'],
+                    },
+                }
+            }
+        }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.2/socket.io.js"></script>
@@ -12,47 +64,47 @@
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-    <div class="container">
-        <header class="header">
-            <h1>🚀 QuickView</h1>
-            <div class="header-info">
+<body class="bg-background text-foreground h-screen overflow-hidden font-sans">
+    <div class="flex flex-col h-screen">
+        <header class="bg-card border-b border-border px-5 h-12 flex justify-between items-center shrink-0">
+            <h1 class="text-base font-semibold tracking-tight">🚀 QuickView</h1>
+            <div class="flex items-center gap-2.5 text-sm text-muted-foreground">
                 <span id="status" class="status">●</span>
                 <span id="current-file">No file selected</span>
             </div>
         </header>
 
-        <div class="main-content">
-            <div class="sidebar">
-                <div class="sidebar-header">
-                    <h3>📁 Files</h3>
-                    <button id="refresh-files" title="Refresh file tree">🔄</button>
+        <div class="flex flex-1 overflow-hidden min-h-0">
+            <aside class="w-72 bg-card border-r border-border flex flex-col overflow-hidden shrink-0">
+                <div class="px-4 py-3 border-b border-border flex justify-between items-center">
+                    <h3 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Files</h3>
+                    <button id="refresh-files" title="Refresh file tree" class="text-muted-foreground hover:text-foreground hover:bg-accent p-1.5 rounded-md transition-colors text-sm leading-none">🔄</button>
                 </div>
-                <div id="file-tree" class="file-tree"></div>
-            </div>
+                <div id="file-tree" class="flex-1 overflow-y-auto p-2"></div>
+            </aside>
 
-            <div class="editor-preview">
-                <div class="tabs">
+            <div class="flex-1 flex flex-col overflow-hidden min-w-0">
+                <div class="flex bg-card border-b border-border shrink-0">
                     <button class="tab active" data-tab="preview">🖥️ Preview</button>
                     <button class="tab" data-tab="code">📝 Code</button>
                     <button class="tab" data-tab="output">📊 Output</button>
                 </div>
 
-                <div class="tab-content">
+                <div class="flex-1 relative overflow-hidden">
                     <div id="preview-panel" class="panel active">
-                        <div id="preview-content">
-                            <div class="welcome">
-                                <h2>Welcome to QuickView!</h2>
-                                <p>Select a file from the sidebar to start previewing</p>
-                                <div class="supported-formats">
-                                    <h3>Supported formats:</h3>
-                                    <ul>
-                                        <li>🌐 HTML/CSS/JavaScript</li>
-                                        <li>⚛️ React Components (JSX)</li>
-                                        <li>🐍 Python Scripts</li>
-                                        <li>🎨 SVG Graphics</li>
-                                        <li>📝 Markdown</li>
-                                        <li>📊 JSON/YAML</li>
+                        <div id="preview-content" class="h-full bg-white">
+                            <div class="px-10 py-16 text-center text-gray-500">
+                                <h2 class="text-2xl font-semibold text-gray-800 mb-3">Welcome to QuickView!</h2>
+                                <p class="text-gray-500 text-sm">Select a file from the sidebar to start previewing</p>
+                                <div class="mt-8 text-left max-w-xs mx-auto">
+                                    <h3 class="text-xs font-medium uppercase tracking-wider text-gray-400 mb-3">Supported formats</h3>
+                                    <ul class="space-y-2">
+                                        <li class="text-sm text-gray-600">🌐 HTML/CSS/JavaScript</li>
+                                        <li class="text-sm text-gray-600">⚛️ React Components (JSX)</li>
+                                        <li class="text-sm text-gray-600">🐍 Python Scripts</li>
+                                        <li class="text-sm text-gray-600">🎨 SVG Graphics</li>
+                                        <li class="text-sm text-gray-600">📝 Markdown</li>
+                                        <li class="text-sm text-gray-600">📊 JSON/YAML</li>
                                     </ul>
                                 </div>
                             </div>
@@ -64,7 +116,7 @@
                     </div>
 
                     <div id="output-panel" class="panel">
-                        <div id="output-content">
+                        <div id="output-content" class="output-content">
                             <div class="output-placeholder">
                                 Script output will appear here...
                             </div>
@@ -72,7 +124,7 @@
                     </div>
                 </div>
 
-                <div class="action-bar">
+                <div class="bg-card border-t border-border px-4 py-2 flex gap-2 shrink-0">
                     <button id="run-code" class="action-btn" style="display: none;">▶️ Run</button>
                     <button id="format-code" class="action-btn" style="display: none;">✨ Format</button>
                     <button id="open-external" class="action-btn" style="display: none;">🔗 Open External</button>
@@ -81,9 +133,9 @@
         </div>
     </div>
 
-    <div id="loading" class="loading" style="display: none;">
+    <div id="loading" style="display: none;" class="fixed inset-0 bg-black/80 flex flex-col justify-center items-center z-50">
         <div class="spinner"></div>
-        <p>Processing...</p>
+        <p class="text-sm text-foreground mt-4">Processing...</p>
     </div>
 
     <script src="app.js"></script>

--- a/quickview-tool/public/style.css
+++ b/quickview-tool/public/style.css
@@ -1,350 +1,255 @@
-*    {
-    margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+/* shadcn/ui design tokens — dark theme default */
+:root {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 7%;
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+    --radius: 0.5rem;
 }
-body    {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: #1a1a1a;
-  color: #ffffff;
-  height: 100vh;
-  overflow: hidden;
-}
-.container    {
-    display: flex;
-  flex-direction: column;
-  height: 100vh;
-}
-.header    {
-    background: #2d2d2d;
-  padding: 10px 20px;
-  border-bottom: 1px solid #444;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.header h1    {
-    font-size: 1.5rem;
-  font-weight: 600;
-}
-.header-info    {
-    display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.9rem;
-}
-.status    {
-    color: #4ade80;
-  font-size: 1.2rem;
-}
-.status.disconnected    {
-    color: #ef4444;
-}
-.main-content    {
-    display: flex;
-  flex: 1;
-  overflow: hidden;
-}
-.sidebar    {
-    width: 300px;
-  background: #252525;
-  border-right: 1px solid #444;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.sidebar-header    {
-    padding: 15px 20px;
-  border-bottom: 1px solid #444;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.sidebar-header h3    {
-    font-size: 1rem;
-  font-weight: 500;
-}
-.sidebar-header button    {
+
+/* Tab navigation */
+.tab {
     background: none;
-  border: none;
-  color: #888;
-  cursor: pointer;
-  font-size: 1rem;
-  padding: 5px;
-  border-radius: 4px;
-  transition: color 0.2s;
+    border: none;
+    color: hsl(var(--muted-foreground));
+    padding: 10px 18px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-family: inherit;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 }
-.sidebar-header button: hover    {
-    color: #fff;
-  background: #444;
+
+.tab:hover {
+    color: hsl(var(--foreground));
+    background: hsl(var(--accent));
 }
-.file-tree    {
-    flex: 1;
-  overflow-y: auto;
-  padding: 10px;
+
+.tab.active {
+    color: hsl(var(--foreground));
+    border-bottom-color: hsl(var(--primary));
 }
-.file-item    {
-    display: flex;
-  align-items: center;
-  padding: 8px 12px;
-  cursor: pointer;
-  border-radius: 6px;
-  transition: background 0.2s;
-  font-size: 0.9rem;
-}
-.file-item: hover    {
-    background: #333;
-}
-.file-item.selected    {
-    background: #4ade80;
-  color: #1a1a1a;
-}
-.file-item.directory    {
-    font-weight: 500;
-}
-.file-item.directory: :before    {
-    content: '📁';
-  margin-right: 8px;
-}
-.file-item.file: :before    {
-    content: '📄';
-  margin-right: 8px;
-}
-.file-item.html: :before    {
-   content: '🌐';
-}
-.file-item.js: :before    {
-   content: '📜';
-}
-.file-item.py: :before    {
-   content: '🐍';
-}
-.file-item.json: :before    {
-   content: '📊';
-}
-.file-item.md: :before    {
-   content: '📝';
-}
-.file-item.svg: :before    {
-   content: '🎨';
-}
-.file-item.css: :before    {
-   content: '🎨';
-}
-.file-children    {
-    margin-left: 20px;
-}
-.editor-preview    {
-    flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.tabs    {
-    display: flex;
-  background: #2d2d2d;
-  border-bottom: 1px solid #444;
-}
-.tab    {
-    background: none;
-  border: none;
-  color: #888;
-  padding: 12px 20px;
-  cursor: pointer;
-  font-size: 0.9rem;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s;
-}
-.tab: hover    {
-    color: #fff;
-  background: #333;
-}
-.tab.active    {
-    color: #4ade80;
-  border-bottom-color: #4ade80;
-}
-.tab-content    {
-    flex: 1;
-  position: relative;
-  overflow: hidden;
-}
-.panel    {
+
+/* Content panels */
+.panel {
     position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: none;
-  overflow: auto;
+    inset: 0;
+    display: none;
+    overflow: auto;
 }
-.panel.active    {
+
+.panel.active {
     display: block;
 }
-#preview-content    {
-    height: 100%;
-  background: #fff;
-  color: #333;
+
+/* Connection status indicator */
+.status {
+    color: hsl(142 71% 45%);
+    font-size: 1rem;
+    line-height: 1;
 }
-.welcome    {
-    padding: 40px;
-  text-align: center;
-  color: #666;
+
+.status.disconnected {
+    color: hsl(0 84% 60%);
 }
-.welcome h2    {
-    margin-bottom: 20px;
-  color: #333;
+
+/* File tree items */
+.file-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    cursor: pointer;
+    border-radius: calc(var(--radius) - 2px);
+    font-size: 0.8125rem;
+    color: hsl(var(--foreground));
+    transition: background 0.1s ease;
+    user-select: none;
 }
-.supported-formats    {
-    margin-top: 30px;
-  text-align: left;
-  max-width: 400px;
-  margin-left: auto;
-  margin-right: auto;
+
+.file-item:hover {
+    background: hsl(var(--accent));
 }
-.supported-formats ul    {
-    list-style: none;
-  margin-top: 15px;
+
+.file-item.selected {
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
 }
-.supported-formats li    {
-    padding: 5px 0;
-  font-size: 0.9rem;
+
+.file-item.directory {
+    font-weight: 500;
 }
-#code-content    {
-    background: #1a1a1a;
-  color: #fff;
-  padding: 20px;
-  font-family: 'Monaco', 'Menlo', monospace;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  height: 100%;
-  overflow: auto;
+
+.file-item.directory::before { content: '📁'; font-size: 0.875rem; }
+.file-item.html::before      { content: '🌐'; font-size: 0.875rem; }
+.file-item.js::before        { content: '📜'; font-size: 0.875rem; }
+.file-item.py::before        { content: '🐍'; font-size: 0.875rem; }
+.file-item.json::before      { content: '📊'; font-size: 0.875rem; }
+.file-item.md::before        { content: '📝'; font-size: 0.875rem; }
+.file-item.svg::before       { content: '🎨'; font-size: 0.875rem; }
+.file-item.css::before       { content: '🎨'; font-size: 0.875rem; }
+.file-item.file:not(.html):not(.js):not(.py):not(.json):not(.md):not(.svg):not(.css)::before {
+    content: '📄';
+    font-size: 0.875rem;
 }
-#output-content    {
-    background: #0a0a0a;
-  color: #4ade80;
-  font-family: 'Monaco', 'Menlo', monospace;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  padding: 20px;
-  height: 100%;
-  overflow: auto;
+
+.no-files {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.8125rem;
+    text-align: center;
+    padding: 24px 12px;
 }
-.output-placeholder    {
-    color: #666;
-  text-align: center;
-  margin-top: 50px;
+
+/* Code panel */
+#code-content {
+    display: block;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    padding: 20px;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', monospace;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    min-height: 100%;
+    overflow: auto;
+    white-space: pre;
 }
-.action-bar    {
-    background: #2d2d2d;
-  padding: 10px 20px;
-  border-top: 1px solid #444;
-  display: flex;
-  gap: 10px;
+
+/* Output panel */
+.output-content {
+    background: hsl(220 13% 5%);
+    color: hsl(142 71% 55%);
+    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', monospace;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    padding: 20px;
+    min-height: 100%;
 }
-.action-btn    {
-    background: #4ade80;
-  color: #1a1a1a;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.9rem;
-  font-weight: 500;
-  transition: background 0.2s;
+
+.output-placeholder {
+    color: hsl(var(--muted-foreground));
+    text-align: center;
+    margin-top: 48px;
+    font-size: 0.875rem;
 }
-.action-btn: hover    {
-    background: #22c55e;
+
+/* Action buttons — shadcn secondary variant */
+.action-btn {
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border: 1px solid hsl(var(--border));
+    padding: 5px 14px;
+    border-radius: calc(var(--radius) - 2px);
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: inherit;
+    transition: background 0.15s ease, opacity 0.15s ease;
 }
-.action-btn: disabled    {
-    background: #666;
-  color: #aaa;
-  cursor: not-allowed;
+
+.action-btn:hover {
+    background: hsl(var(--accent));
 }
-.loading    {
-    position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
+
+.action-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
-.spinner    {
-    width: 40px;
-  height: 40px;
-  border: 4px solid #333;
-  border-top: 4px solid #4ade80;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-bottom: 20px;
-}
-@keyframes spin    {
-    0%    {
-   transform: rotate(0deg);
-}
-    100%    {
-   transform: rotate(360deg);
-}
-}
-/* Preview iframe styles */
-.preview-iframe    {
+
+/* Preview iframe */
+.preview-iframe {
     width: 100%;
-  height: 100%;
-  border: none;
-  background: white;
+    height: 100%;
+    border: none;
+    background: white;
 }
-/* Error styles */
-.error    {
-    background: #2d1b1b;
-  color: #ef4444;
-  padding: 20px;
-  margin: 10px;
-  border-radius: 6px;
-  border-left: 4px solid #ef4444;
+
+/* Error message */
+.error {
+    background: hsl(0 62.8% 30.6% / 0.12);
+    color: hsl(0 84% 70%);
+    padding: 14px 16px;
+    margin: 12px;
+    border-radius: var(--radius);
+    border-left: 3px solid hsl(0 62.8% 50%);
+    font-size: 0.875rem;
 }
-.error pre    {
-    background: #1a0a0a;
-  padding: 10px;
-  border-radius: 4px;
-  overflow-x: auto;
-  margin-top: 10px;
+
+.error pre {
+    background: hsl(0 62.8% 30.6% / 0.1);
+    padding: 10px;
+    border-radius: calc(var(--radius) - 2px);
+    overflow-x: auto;
+    margin-top: 8px;
+    font-size: 0.8125rem;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', monospace;
 }
-/* Success styles */
-.success    {
-    background: #1a2d1a;
-  color: #4ade80;
-  padding: 20px;
-  margin: 10px;
-  border-radius: 6px;
-  border-left: 4px solid #4ade80;
+
+/* Success message */
+.success {
+    background: hsl(142 71% 36% / 0.12);
+    color: hsl(142 71% 60%);
+    padding: 14px 16px;
+    margin: 12px;
+    border-radius: var(--radius);
+    border-left: 3px solid hsl(142 71% 45%);
+    font-size: 0.875rem;
 }
-/* Responsive design */
-@media (max-width: 768px)    {
-    .sidebar    {
-        width: 250px;
+
+.success pre {
+    background: hsl(142 71% 36% / 0.1);
+    padding: 10px;
+    border-radius: calc(var(--radius) - 2px);
+    overflow-x: auto;
+    margin-top: 8px;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', monospace;
+    font-size: 0.8125rem;
 }
-    .header h1    {
-        font-size: 1.2rem;
+
+/* Loading spinner */
+.spinner {
+    width: 32px;
+    height: 32px;
+    border: 2px solid hsl(var(--border));
+    border-top: 2px solid hsl(var(--primary));
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
 }
-    .tabs    {
-        overflow-x: auto;
+
+@keyframes spin {
+    0%   { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
 }
-/* Scrollbar styles */
-: :-webkit-scrollbar    {
-    width: 8px;
+
+::-webkit-scrollbar-track {
+    background: transparent;
 }
-: :-webkit-scrollbar-track    {
-    background: #2d2d2d;
+
+::-webkit-scrollbar-thumb {
+    background: hsl(var(--border));
+    border-radius: 3px;
 }
-: :-webkit-scrollbar-thumb    {
-    background: #555;
-  border-radius: 4px;
-}
-: :-webkit-scrollbar-thumb:hover    {
-    background: #666;
+
+::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.5);
 }


### PR DESCRIPTION
Converts the QuickView frontend to use Tailwind CSS (CDN) and shadcn/ui design tokens (CSS variables for colors, radius, typography).

Changes:
- Tailwind CSS via CDN with shadcn color configuration
- shadcn dark theme CSS variables as the design foundation
- Inter + JetBrains Mono typography
- Full Tailwind utility class layout replacing hand-rolled CSS

Closes #1

Generated with [Claude Code](https://claude.ai/code)