### PR TITLE
refactor: decompose monolithic server and client into focused modules

### DIFF
--- a/quickview-tool/public/app.js
+++ b/quickview-tool/public/app.js
@@ -1,474 +1,203 @@
+import { renderHTML } from './js/renderers/html-renderer.js';
+import { renderReact } from './js/renderers/react-renderer.js';
+import { renderPythonPreview } from './js/renderers/python-renderer.js';
+import { renderSVG } from './js/renderers/svg-renderer.js';
+import { renderMarkdown } from './js/renderers/markdown-renderer.js';
+import { renderJSON } from './js/renderers/json-renderer.js';
+import { escapeHtml } from './js/utils.js';
+import { FileTreeManager } from './js/managers/file-tree-manager.js';
+import { TabManager } from './js/managers/tab-manager.js';
+import { SocketManager } from './js/managers/socket-manager.js';
+
+const HIGHLIGHT_LANG_MAP = {
+  '.js': 'javascript',
+  '.jsx': 'javascript',
+  '.py': 'python',
+  '.html': 'html',
+  '.css': 'css',
+  '.json': 'json',
+  '.md': 'markdown',
+  '.svg': 'xml'
+};
+
+const FORMATTABLE_EXTENSIONS = ['.js', '.jsx', '.json', '.html', '.css'];
+
 class QuickViewApp {
-    constructor() {
-        this.socket = io();
-        this.currentFile = null;
-        this.fileTree = null;
-        this.setupSocketHandlers();
-        this.setupUIHandlers();
-        this.setupTabs();
-    }
+  constructor() {
+    this.currentFile = null;
 
-    setupSocketHandlers() {
-        this.socket.on('connect', () => {
-            this.updateStatus('connected');
-            console.log('Connected to QuickView server');
-        });
+    this.tabManager = new TabManager();
 
-        this.socket.on('disconnect', () => {
-            this.updateStatus('disconnected');
-            console.log('Disconnected from QuickView server');
-        });
+    this.fileTreeManager = new FileTreeManager('file-tree', (file) => {
+      this.loadFile(file);
+    });
 
-        this.socket.on('fileTree', (tree) => {
-            this.fileTree = tree;
-            this.renderFileTree();
-        });
-
-        this.socket.on('fileChange', (data) => {
-            console.log('File changed:', data);
-            if (this.currentFile && data.relativePath === this.currentFile.path) {
-                this.loadFile(this.currentFile);
-            }
-            // Update file tree if needed
-            if (data.event === 'add' || data.event === 'unlink') {
-                // File tree will be updated via fileTree event
-            }
-        });
-    }
-
-    setupUIHandlers() {
-        document.getElementById('refresh-files').addEventListener('click', () => {
-            this.socket.emit('refreshFiles');
-        });
-
-        document.getElementById('run-code').addEventListener('click', () => {
-            this.runCode();
-        });
-
-        document.getElementById('format-code').addEventListener('click', () => {
-            this.formatCode();
-        });
-
-        document.getElementById('open-external').addEventListener('click', () => {
-            this.openExternal();
-        });
-    }
-
-    setupTabs() {
-        const tabs = document.querySelectorAll('.tab');
-        const panels = document.querySelectorAll('.panel');
-
-        tabs.forEach(tab => {
-            tab.addEventListener('click', () => {
-                const targetPanel = tab.dataset.tab;
-                
-                tabs.forEach(t => t.classList.remove('active'));
-                panels.forEach(p => p.classList.remove('active'));
-                
-                tab.classList.add('active');
-                document.getElementById(`${targetPanel}-panel`).classList.add('active');
-            });
-        });
-    }
-
-    updateStatus(status) {
-        const statusElement = document.getElementById('status');
-        statusElement.className = `status ${status}`;
-    }
-
-    renderFileTree() {
-        const container = document.getElementById('file-tree');
-        container.innerHTML = '';
-        
-        if (this.fileTree && this.fileTree.length > 0) {
-            this.renderFileItems(this.fileTree, container);
-        } else {
-            container.innerHTML = '<div class="no-files">No files found</div>';
+    this.socketManager = new SocketManager(
+      (tree) => this.fileTreeManager.render(tree),
+      (data) => {
+        if (this.currentFile && data.relativePath === this.currentFile.path) {
+          this.loadFile(this.currentFile);
         }
-    }
+      }
+    );
 
-    renderFileItems(items, container, level = 0) {
-        items.forEach(item => {
-            const element = document.createElement('div');
-            element.className = `file-item ${item.type} ${this.getFileClass(item.extension)}`;
-            element.style.paddingLeft = `${12 + (level * 16)}px`;
-            element.textContent = item.name;
-            
-            if (item.type === 'file') {
-                element.addEventListener('click', () => {
-                    this.selectFile(item, element);
-                });
-            }
-            
-            container.appendChild(element);
-            
-            if (item.children && item.children.length > 0) {
-                this.renderFileItems(item.children, container, level + 1);
-            }
-        });
-    }
+    this.setupUIHandlers();
+  }
 
-    getFileClass(extension) {
-        if (!extension) return 'file';
-        
-        const ext = extension.toLowerCase().replace('.', '');
-        const classMap = {
-            'html': 'html',
-            'js': 'js',
-            'jsx': 'js',
-            'py': 'py',
-            'json': 'json',
-            'md': 'md',
-            'svg': 'svg',
-            'css': 'css'
-        };
-        
-        return classMap[ext] || 'file';
-    }
+  setupUIHandlers() {
+    document.getElementById('refresh-files').addEventListener('click', () => {
+      this.socketManager.requestRefresh();
+    });
 
-    selectFile(file, element) {
-        // Remove previous selection
-        document.querySelectorAll('.file-item.selected').forEach(item => {
-            item.classList.remove('selected');
-        });
-        
-        // Add selection to clicked item
-        element.classList.add('selected');
-        
-        this.currentFile = file;
-        this.loadFile(file);
-    }
+    document.getElementById('run-code').addEventListener('click', () => this.runCode());
+    document.getElementById('format-code').addEventListener('click', () => this.formatCode());
+    document.getElementById('open-external').addEventListener('click', () => this.openExternal());
+  }
 
-    async loadFile(file) {
-        this.showLoading(true);
-        
-        try {
-            const response = await fetch(`/api/file/${file.path}`);
-            const data = await response.json();
-            
-            if (!response.ok) {
-                throw new Error(data.error || 'Failed to load file');
-            }
-            
-            document.getElementById('current-file').textContent = file.name;
-            
-            // Update code panel
-            this.updateCodePanel(data.content, data.extension);
-            
-            // Update preview panel
-            this.updatePreviewPanel(data.content, data.extension, file.name);
-            
-            // Update action buttons
-            this.updateActionButtons(data.extension);
-            
-        } catch (error) {
-            console.error('Error loading file:', error);
-            this.showError('Failed to load file: ' + error.message);
-        } finally {
-            this.showLoading(false);
-        }
-    }
+  async loadFile(file) {
+    this.showLoading(true);
 
-    updateCodePanel(content, extension) {
-        const codeElement = document.getElementById('code-content');
-        codeElement.textContent = content;
-        
-        // Apply syntax highlighting
-        if (window.hljs) {
-            const language = this.getHighlightLanguage(extension);
-            if (language) {
-                codeElement.className = `language-${language}`;
-                hljs.highlightElement(codeElement);
-            }
-        }
-    }
+    try {
+      const response = await fetch(`/api/file/${file.path}`);
+      const data = await response.json();
 
-    getHighlightLanguage(extension) {
-        const langMap = {
-            '.js': 'javascript',
-            '.jsx': 'javascript',
-            '.py': 'python',
-            '.html': 'html',
-            '.css': 'css',
-            '.json': 'json',
-            '.md': 'markdown',
-            '.svg': 'xml'
-        };
-        
-        return langMap[extension] || null;
-    }
+      if (!response.ok) throw new Error(data.error || 'Failed to load file');
 
-    updatePreviewPanel(content, extension, filename) {
-        const previewContent = document.getElementById('preview-content');
-        
-        switch (extension) {
-            case '.html':
-                this.renderHTML(previewContent, content);
-                break;
-                
-            case '.jsx':
-                this.renderReact(previewContent, content);
-                break;
-                
-            case '.py':
-                this.renderPythonPreview(previewContent, content, filename);
-                break;
-                
-            case '.svg':
-                this.renderSVG(previewContent, content);
-                break;
-                
-            case '.md':
-                this.renderMarkdown(previewContent, content);
-                break;
-                
-            case '.json':
-                this.renderJSON(previewContent, content);
-                break;
-                
-            default:
-                this.renderText(previewContent, content);
-        }
-    }
+      this.currentFile = file;
+      document.getElementById('current-file').textContent = file.name;
 
-    renderHTML(container, content) {
-        const iframe = document.createElement('iframe');
-        iframe.className = 'preview-iframe';
-        iframe.srcdoc = content;
-        
-        container.innerHTML = '';
-        container.appendChild(iframe);
+      this.updateCodePanel(data.content, data.extension);
+      this.updatePreviewPanel(data.content, data.extension, file.name);
+      this.updateActionButtons(data.extension);
+    } catch (error) {
+      this.showError('Failed to load file: ' + error.message);
+    } finally {
+      this.showLoading(false);
     }
+  }
 
-    renderReact(container, content) {
-        try {
-            // Create a wrapper for React component
-            const wrapper = document.createElement('div');
-            wrapper.id = 'react-preview';
-            container.innerHTML = '';
-            container.appendChild(wrapper);
-            
-            // Transform JSX using Babel
-            const transformed = Babel.transform(content, {
-                presets: ['react']
-            }).code;
-            
-            // Create and execute the component
-            const script = document.createElement('script');
-            script.textContent = `
-                try {
-                    ${transformed}
-                    
-                    // Try to find and render the component
-                    const componentName = Object.keys(window).find(key => 
-                        typeof window[key] === 'function' && 
-                        key[0] === key[0].toUpperCase()
-                    );
-                    
-                    if (componentName) {
-                        const Component = window[componentName];
-                        ReactDOM.render(React.createElement(Component), document.getElementById('react-preview'));
-                    }
-                } catch (error) {
-                    document.getElementById('react-preview').innerHTML = 
-                        '<div class="error">React Error: ' + error.message + '</div>';
-                }
-            `;
-            
-            document.head.appendChild(script);
-            setTimeout(() => document.head.removeChild(script), 100);
-            
-        } catch (error) {
-            container.innerHTML = `<div class="error">Failed to render React component: ${error.message}</div>`;
-        }
+  updateCodePanel(content, extension) {
+    const codeElement = document.getElementById('code-content');
+    codeElement.textContent = content;
+
+    if (window.hljs) {
+      const language = HIGHLIGHT_LANG_MAP[extension];
+      if (language) {
+        codeElement.className = `language-${language}`;
+        hljs.highlightElement(codeElement);
+      }
     }
+  }
 
-    renderPythonPreview(container, content, filename) {
-        container.innerHTML = `
-            <div style="padding: 20px; color: #333;">
-                <h3>Python Script: ${filename}</h3>
-                <p>Click "Run" to execute this Python script and see the output.</p>
-                <div style="margin-top: 20px; padding: 15px; background: #f5f5f5; border-radius: 6px;">
-                    <strong>Script Preview:</strong>
-                    <pre style="margin-top: 10px; overflow-x: auto;">${this.escapeHtml(content.substring(0, 500))}${content.length > 500 ? '...' : ''}</pre>
-                </div>
-            </div>
-        `;
+  updatePreviewPanel(content, extension, filename) {
+    const previewContent = document.getElementById('preview-content');
+    const renderers = {
+      '.html': () => renderHTML(previewContent, content),
+      '.jsx': () => renderReact(previewContent, content),
+      '.py': () => renderPythonPreview(previewContent, content, filename),
+      '.svg': () => renderSVG(previewContent, content),
+      '.md': () => renderMarkdown(previewContent, content),
+      '.json': () => renderJSON(previewContent, content)
+    };
+
+    const renderer = renderers[extension];
+    if (renderer) {
+      renderer();
+    } else {
+      previewContent.innerHTML = `
+        <div style="padding: 20px; color: #333;">
+          <pre style="white-space: pre-wrap; font-family: monospace;">${escapeHtml(content)}</pre>
+        </div>
+      `;
     }
+  }
 
-    renderSVG(container, content) {
-        container.innerHTML = `
-            <div style="padding: 20px; text-align: center; background: white;">
-                ${content}
-            </div>
-        `;
+  updateActionButtons(extension) {
+    document.getElementById('run-code').style.display = extension === '.py' ? 'block' : 'none';
+    document.getElementById('format-code').style.display = FORMATTABLE_EXTENSIONS.includes(extension) ? 'block' : 'none';
+    document.getElementById('open-external').style.display = extension === '.html' ? 'block' : 'none';
+  }
+
+  async runCode() {
+    if (!this.currentFile || this.currentFile.extension !== '.py') return;
+
+    this.showLoading(true);
+
+    try {
+      const fileResponse = await fetch(`/api/file/${this.currentFile.path}`);
+      const fileData = await fileResponse.json();
+
+      const execResponse = await fetch('/api/execute/python', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: fileData.content, filename: this.currentFile.name })
+      });
+
+      const result = await execResponse.json();
+
+      this.tabManager.switchTo('output');
+
+      const outputContent = document.getElementById('output-content');
+      outputContent.innerHTML = result.success
+        ? `<div class="success"><strong>✅ Execution completed successfully</strong><pre>${escapeHtml(result.output || 'No output')}</pre></div>`
+        : `<div class="error"><strong>❌ Execution failed</strong><pre>${escapeHtml(result.error || 'Unknown error')}</pre></div>`;
+    } catch (error) {
+      this.showError('Failed to execute Python script: ' + error.message);
+    } finally {
+      this.showLoading(false);
     }
+  }
 
-    renderMarkdown(container, content) {
-        // Simple markdown rendering (would use marked.js in production)
-        const html = content
-            .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-            .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-            .replace(/^### (.*$)/gim, '<h3>$1</h3>')
-            .replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>')
-            .replace(/\*(.*)\*/gim, '<em>$1</em>')
-            .replace(/\n/gim, '<br>');
-            
-        container.innerHTML = `<div style="padding: 20px; color: #333;">${html}</div>`;
-    }
+  async formatCode() {
+    if (!this.currentFile) return;
 
-    renderJSON(container, content) {
-        try {
-            const parsed = JSON.parse(content);
-            const formatted = JSON.stringify(parsed, null, 2);
-            container.innerHTML = `
-                <div style="padding: 20px; color: #333;">
-                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 6px; overflow-x: auto;">${this.escapeHtml(formatted)}</pre>
-                </div>
-            `;
-        } catch (error) {
-            container.innerHTML = `<div class="error">Invalid JSON: ${error.message}</div>`;
-        }
-    }
+    this.showLoading(true);
 
-    renderText(container, content) {
-        container.innerHTML = `
-            <div style="padding: 20px; color: #333;">
-                <pre style="white-space: pre-wrap; font-family: monospace;">${this.escapeHtml(content)}</pre>
-            </div>
-        `;
-    }
+    try {
+      const response = await fetch('/api/format', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filepath: this.currentFile.path,
+          extension: this.currentFile.extension
+        })
+      });
 
-    updateActionButtons(extension) {
-        const runBtn = document.getElementById('run-code');
+      const result = await response.json();
+
+      if (result.success) {
+        this.loadFile(this.currentFile);
         const formatBtn = document.getElementById('format-code');
-        const openBtn = document.getElementById('open-external');
-        
-        // Show/hide buttons based on file type
-        runBtn.style.display = extension === '.py' ? 'block' : 'none';
-        formatBtn.style.display = ['.js', '.jsx', '.json', '.html', '.css'].includes(extension) ? 'block' : 'none';
-        openBtn.style.display = extension === '.html' ? 'block' : 'none';
+        const originalText = formatBtn.textContent;
+        formatBtn.textContent = '✓ Formatted';
+        formatBtn.style.background = '#10b981';
+        setTimeout(() => {
+          formatBtn.textContent = originalText;
+          formatBtn.style.background = '';
+        }, 2000);
+      } else {
+        this.showError('Failed to format code: ' + result.error);
+      }
+    } catch (error) {
+      this.showError('Failed to format code: ' + error.message);
+    } finally {
+      this.showLoading(false);
     }
+  }
 
-    async runCode() {
-        if (!this.currentFile || this.currentFile.extension !== '.py') return;
-        
-        this.showLoading(true);
-        
-        try {
-            const response = await fetch(`/api/file/${this.currentFile.path}`);
-            const data = await response.json();
-            
-            const execResponse = await fetch('/api/execute/python', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    code: data.content,
-                    filename: this.currentFile.name
-                })
-            });
-            
-            const result = await execResponse.json();
-            
-            // Switch to output tab and show results
-            document.querySelector('[data-tab="output"]').click();
-            
-            const outputContent = document.getElementById('output-content');
-            if (result.success) {
-                outputContent.innerHTML = `
-                    <div class="success">
-                        <strong>✅ Execution completed successfully</strong>
-                        <pre>${this.escapeHtml(result.output || 'No output')}</pre>
-                    </div>
-                `;
-            } else {
-                outputContent.innerHTML = `
-                    <div class="error">
-                        <strong>❌ Execution failed</strong>
-                        <pre>${this.escapeHtml(result.error || 'Unknown error')}</pre>
-                    </div>
-                `;
-            }
-            
-        } catch (error) {
-            console.error('Error running code:', error);
-            this.showError('Failed to execute Python script: ' + error.message);
-        } finally {
-            this.showLoading(false);
-        }
+  openExternal() {
+    if (this.currentFile && this.currentFile.extension === '.html') {
+      window.open(`/preview/${this.currentFile.path}`, '_blank');
     }
+  }
 
-    async formatCode() {
-        if (!this.currentFile) return;
-        
-        this.showLoading(true);
-        
-        try {
-            const response = await fetch(`/api/format`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    filepath: this.currentFile.path,
-                    extension: this.currentFile.extension
-                })
-            });
-            
-            const result = await response.json();
-            
-            if (result.success) {
-                // Reload the file to show formatted content
-                this.loadFile(this.currentFile);
-                
-                // Show success message briefly
-                const formatBtn = document.getElementById('format-code');
-                const originalText = formatBtn.textContent;
-                formatBtn.textContent = '✓ Formatted';
-                formatBtn.style.background = '#10b981';
-                
-                setTimeout(() => {
-                    formatBtn.textContent = originalText;
-                    formatBtn.style.background = '';
-                }, 2000);
-            } else {
-                this.showError('Failed to format code: ' + result.error);
-            }
-            
-        } catch (error) {
-            console.error('Error formatting code:', error);
-            this.showError('Failed to format code: ' + error.message);
-        } finally {
-            this.showLoading(false);
-        }
-    }
+  showLoading(show) {
+    document.getElementById('loading').style.display = show ? 'flex' : 'none';
+  }
 
-    openExternal() {
-        if (this.currentFile && this.currentFile.extension === '.html') {
-            window.open(`/preview/${this.currentFile.path}`, '_blank');
-        }
-    }
-
-    showLoading(show) {
-        const loading = document.getElementById('loading');
-        loading.style.display = show ? 'flex' : 'none';
-    }
-
-    showError(message) {
-        const previewContent = document.getElementById('preview-content');
-        previewContent.innerHTML = `<div class="error">${message}</div>`;
-    }
-
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
+  showError(message) {
+    document.getElementById('preview-content').innerHTML = `<div class="error">${message}</div>`;
+  }
 }
 
-// Initialize the app when the page loads
-document.addEventListener('DOMContentLoaded', () => {
-    new QuickViewApp();
-});
+document.addEventListener('DOMContentLoaded', () => new QuickViewApp());

--- a/quickview-tool/public/index.html
+++ b/quickview-tool/public/index.html
@@ -138,6 +138,6 @@
         <p class="text-sm text-foreground mt-4">Processing...</p>
     </div>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/quickview-tool/public/js/managers/file-tree-manager.js
+++ b/quickview-tool/public/js/managers/file-tree-manager.js
@@ -1,0 +1,48 @@
+export class FileTreeManager {
+  constructor(containerId, onFileSelect) {
+    this.container = document.getElementById(containerId);
+    this.onFileSelect = onFileSelect;
+  }
+
+  render(fileTree) {
+    this.container.innerHTML = '';
+    if (fileTree && fileTree.length > 0) {
+      this.renderItems(fileTree, this.container);
+    } else {
+      this.container.innerHTML = '<div class="no-files">No files found</div>';
+    }
+  }
+
+  renderItems(items, container, level = 0) {
+    items.forEach(item => {
+      const element = document.createElement('div');
+      element.className = `file-item ${item.type} ${this.getFileClass(item.extension)}`;
+      element.style.paddingLeft = `${12 + (level * 16)}px`;
+      element.textContent = item.name;
+
+      if (item.type === 'file') {
+        element.addEventListener('click', () => {
+          document.querySelectorAll('.file-item.selected').forEach(el => el.classList.remove('selected'));
+          element.classList.add('selected');
+          this.onFileSelect(item);
+        });
+      }
+
+      container.appendChild(element);
+
+      if (item.children && item.children.length > 0) {
+        this.renderItems(item.children, container, level + 1);
+      }
+    });
+  }
+
+  getFileClass(extension) {
+    if (!extension) return 'file';
+    const ext = extension.toLowerCase().replace('.', '');
+    const classMap = {
+      html: 'html', js: 'js', jsx: 'js', py: 'py',
+      json: 'json', md: 'md', svg: 'svg', css: 'css'
+    };
+    return classMap[ext] || 'file';
+  }
+}

--- a/quickview-tool/public/js/managers/socket-manager.js
+++ b/quickview-tool/public/js/managers/socket-manager.js
@@ -1,0 +1,25 @@
+export class SocketManager {
+  constructor(onFileTree, onFileChange) {
+    this.socket = window.io();
+    this.onFileTree = onFileTree;
+    this.onFileChange = onFileChange;
+    this.setup();
+  }
+
+  setup() {
+    this.socket.on('connect', () => {
+      document.getElementById('status').className = 'status connected';
+    });
+
+    this.socket.on('disconnect', () => {
+      document.getElementById('status').className = 'status disconnected';
+    });
+
+    this.socket.on('fileTree', (tree) => this.onFileTree(tree));
+    this.socket.on('fileChange', (data) => this.onFileChange(data));
+  }
+
+  requestRefresh() {
+    this.socket.emit('refreshFiles');
+  }
+}

--- a/quickview-tool/public/js/managers/tab-manager.js
+++ b/quickview-tool/public/js/managers/tab-manager.js
@@ -1,0 +1,24 @@
+export class TabManager {
+  constructor() {
+    this.tabs = document.querySelectorAll('.tab');
+    this.panels = document.querySelectorAll('.panel');
+    this.setup();
+  }
+
+  setup() {
+    this.tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const targetPanel = tab.dataset.tab;
+        this.tabs.forEach(t => t.classList.remove('active'));
+        this.panels.forEach(p => p.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById(`${targetPanel}-panel`).classList.add('active');
+      });
+    });
+  }
+
+  switchTo(tabName) {
+    const tab = document.querySelector(`[data-tab="${tabName}"]`);
+    if (tab) tab.click();
+  }
+}

--- a/quickview-tool/public/js/renderers/html-renderer.js
+++ b/quickview-tool/public/js/renderers/html-renderer.js
@@ -1,0 +1,7 @@
+export function renderHTML(container, content) {
+  const iframe = document.createElement('iframe');
+  iframe.className = 'preview-iframe';
+  iframe.srcdoc = content;
+  container.innerHTML = '';
+  container.appendChild(iframe);
+}

--- a/quickview-tool/public/js/renderers/json-renderer.js
+++ b/quickview-tool/public/js/renderers/json-renderer.js
@@ -1,0 +1,14 @@
+import { escapeHtml } from '../utils.js';
+
+export function renderJSON(container, content) {
+  try {
+    const formatted = JSON.stringify(JSON.parse(content), null, 2);
+    container.innerHTML = `
+      <div style="padding: 20px; color: #333;">
+        <pre style="background: #f5f5f5; padding: 15px; border-radius: 6px; overflow-x: auto;">${escapeHtml(formatted)}</pre>
+      </div>
+    `;
+  } catch (error) {
+    container.innerHTML = `<div class="error">Invalid JSON: ${error.message}</div>`;
+  }
+}

--- a/quickview-tool/public/js/renderers/markdown-renderer.js
+++ b/quickview-tool/public/js/renderers/markdown-renderer.js
@@ -1,0 +1,11 @@
+export function renderMarkdown(container, content) {
+  const html = content
+    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+    .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+    .replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>')
+    .replace(/\*(.*)\*/gim, '<em>$1</em>')
+    .replace(/\n/gim, '<br>');
+
+  container.innerHTML = `<div style="padding: 20px; color: #333;">${html}</div>`;
+}

--- a/quickview-tool/public/js/renderers/python-renderer.js
+++ b/quickview-tool/public/js/renderers/python-renderer.js
@@ -1,0 +1,14 @@
+import { escapeHtml } from '../utils.js';
+
+export function renderPythonPreview(container, content, filename) {
+  container.innerHTML = `
+    <div style="padding: 20px; color: #333;">
+      <h3>Python Script: ${filename}</h3>
+      <p>Click "Run" to execute this Python script and see the output.</p>
+      <div style="margin-top: 20px; padding: 15px; background: #f5f5f5; border-radius: 6px;">
+        <strong>Script Preview:</strong>
+        <pre style="margin-top: 10px; overflow-x: auto;">${escapeHtml(content.substring(0, 500))}${content.length > 500 ? '...' : ''}</pre>
+      </div>
+    </div>
+  `;
+}

--- a/quickview-tool/public/js/renderers/react-renderer.js
+++ b/quickview-tool/public/js/renderers/react-renderer.js
@@ -1,0 +1,32 @@
+export function renderReact(container, content) {
+  try {
+    const wrapper = document.createElement('div');
+    wrapper.id = 'react-preview';
+    container.innerHTML = '';
+    container.appendChild(wrapper);
+
+    const transformed = Babel.transform(content, { presets: ['react'] }).code;
+
+    const script = document.createElement('script');
+    script.textContent = `
+      try {
+        ${transformed}
+        const componentName = Object.keys(window).find(key =>
+          typeof window[key] === 'function' && key[0] === key[0].toUpperCase()
+        );
+        if (componentName) {
+          const Component = window[componentName];
+          ReactDOM.render(React.createElement(Component), document.getElementById('react-preview'));
+        }
+      } catch (error) {
+        document.getElementById('react-preview').innerHTML =
+          '<div class="error">React Error: ' + error.message + '</div>';
+      }
+    `;
+
+    document.head.appendChild(script);
+    setTimeout(() => document.head.removeChild(script), 100);
+  } catch (error) {
+    container.innerHTML = `<div class="error">Failed to render React component: ${error.message}</div>`;
+  }
+}

--- a/quickview-tool/public/js/renderers/svg-renderer.js
+++ b/quickview-tool/public/js/renderers/svg-renderer.js
@@ -1,0 +1,7 @@
+export function renderSVG(container, content) {
+  container.innerHTML = `
+    <div style="padding: 20px; text-align: center; background: white;">
+      ${content}
+    </div>
+  `;
+}

--- a/quickview-tool/public/js/utils.js
+++ b/quickview-tool/public/js/utils.js
@@ -1,0 +1,5 @@
+export function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}

--- a/quickview-tool/server.js
+++ b/quickview-tool/server.js
@@ -1,20 +1,31 @@
 const express = require('express');
 const http = require('http');
 const socketIo = require('socket.io');
-const chokidar = require('chokidar');
 const path = require('path');
-const fs = require('fs');
-const { spawn } = require('child_process');
-const open = require('open');
+
+const FileService = require('./src/services/file-service');
+const PythonExecutor = require('./src/services/python-executor');
+const CodeFormatter = require('./src/services/code-formatter');
+const FileWatcher = require('./src/services/file-watcher');
+
+const createFileRoutes = require('./src/routes/file-routes');
+const createExecuteRoutes = require('./src/routes/execute-routes');
+const createFormatRoutes = require('./src/routes/format-routes');
 
 class QuickViewServer {
   constructor(options = {}) {
     this.port = options.port || 3333;
     this.watchDir = options.watchDir || process.cwd();
+
     this.app = express();
     this.server = http.createServer(this.app);
     this.io = socketIo(this.server);
-    this.pythonExecutionCount = new Map(); // Rate limiting for Python execution
+
+    this.fileService = new FileService(this.watchDir);
+    this.pythonExecutor = new PythonExecutor();
+    this.codeFormatter = new CodeFormatter();
+    this.fileWatcher = new FileWatcher(this.watchDir);
+
     this.setupMiddleware();
     this.setupRoutes();
     this.setupSocketHandlers();
@@ -28,396 +39,60 @@ class QuickViewServer {
   }
 
   setupRoutes() {
-    // Main preview interface
     this.app.get('/', (req, res) => {
       res.sendFile(path.join(__dirname, 'public', 'index.html'));
     });
 
-    // API to get file content
-    this.app.get('/api/file/*', (req, res) => {
-      const requestedPath = req.params[0];
-      const filename = path.basename(requestedPath);
-      
-      // Security: Prevent serving hidden/sensitive files
-      if (filename.startsWith('.') && !filename.endsWith('.html')) {
-        return res.status(403).json({ error: 'Access to hidden files denied' });
-      }
-      
-      // Security: Basic file type restrictions
-      const allowedExtensions = ['.html', '.jsx', '.js', '.py', '.css', '.json', '.md', '.svg', '.txt', '.xml', '.yaml', '.yml'];
-      const ext = path.extname(filename).toLowerCase();
-      if (ext && !allowedExtensions.includes(ext)) {
-        return res.status(403).json({ error: 'File type not supported for security reasons' });
-      }
-      
-      const filePath = path.join(this.watchDir, requestedPath);
-      
-      if (!fs.existsSync(filePath)) {
-        return res.status(404).json({ error: 'File not found' });
-      }
-
-      try {
-        const content = fs.readFileSync(filePath, 'utf8');
-        
-        res.json({
-          content,
-          extension: ext,
-          filename: filename,
-          path: requestedPath // Don't expose full system path
-        });
-      } catch (error) {
-        res.status(500).json({ error: 'Unable to read file' });
-      }
-    });
-
-    // API to execute Python scripts
-    this.app.post('/api/execute/python', (req, res) => {
-      const { code, filename } = req.body;
-      const clientIP = req.ip || req.connection.remoteAddress || 'unknown';
-      
-      // Simple rate limiting: max 5 executions per minute per IP
-      const now = Date.now();
-      const executions = this.pythonExecutionCount.get(clientIP) || [];
-      const recentExecutions = executions.filter(time => now - time < 60000); // Last minute
-      
-      if (recentExecutions.length >= 5) {
-        return res.status(429).json({ 
-          error: 'Too many Python executions. Please wait a minute before trying again.',
-          success: false 
-        });
-      }
-      
-      // Update execution count
-      recentExecutions.push(now);
-      this.pythonExecutionCount.set(clientIP, recentExecutions);
-      
-      // Basic input validation
-      if (!code || typeof code !== 'string') {
-        return res.status(400).json({ error: 'Invalid Python code provided', success: false });
-      }
-      
-      if (code.length > 50000) { // 50KB limit
-        return res.status(400).json({ error: 'Python code too large (max 50KB)', success: false });
-      }
-      
-      const tempFile = path.join(__dirname, 'temp', `${filename || 'temp'}_${Date.now()}.py`);
-      
-      // Ensure temp directory exists
-      const tempDir = path.dirname(tempFile);
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-
-      try {
-        fs.writeFileSync(tempFile, code);
-      } catch (error) {
-        return res.status(500).json({ error: 'Failed to create temp file', success: false });
-      }
-
-      const python = spawn('python3', [tempFile], {
-        timeout: 30000, // 30 second timeout
-        killSignal: 'SIGKILL'
-      });
-      let output = '';
-      let error = '';
-
-      python.stdout.on('data', (data) => {
-        output += data.toString();
-      });
-
-      python.stderr.on('data', (data) => {
-        error += data.toString();
-      });
-
-      python.on('close', (code) => {
-        // Clean up temp file
-        try {
-          fs.unlinkSync(tempFile);
-        } catch (cleanupError) {
-          console.warn('Failed to clean up temp file:', tempFile);
-        }
-        
-        res.json({
-          success: code === 0,
-          output: output,
-          error: error,
-          exitCode: code
-        });
-      });
-
-      // Handle timeout
-      python.on('error', (err) => {
-        try {
-          fs.unlinkSync(tempFile);
-        } catch (cleanupError) {
-          console.warn('Failed to clean up temp file after error:', tempFile);
-        }
-        
-        if (err.code === 'ETIMEDOUT') {
-          res.status(408).json({
-            success: false,
-            error: 'Python script execution timed out (30 second limit)',
-            output: output,
-            exitCode: -1
-          });
-        } else {
-          res.status(500).json({
-            success: false,
-            error: 'Failed to execute Python script: ' + err.message,
-            output: output,
-            exitCode: -1
-          });
-        }
-      });
-    });
-
-    // API to list files in directory
-    this.app.get('/api/files', (req, res) => {
-      const files = this.getFileTree(this.watchDir);
-      res.json(files);
-    });
-
-    // API to format code files
-    this.app.post('/api/format', (req, res) => {
-      const { filepath, extension } = req.body;
-      
-      if (!filepath || !extension) {
-        return res.status(400).json({ success: false, error: 'Missing filepath or extension' });
-      }
-      
-      const fullPath = path.join(this.watchDir, filepath);
-      
-      try {
-        // Read current file content
-        const content = fs.readFileSync(fullPath, 'utf8');
-        let formattedContent;
-        
-        // Format based on file type
-        switch (extension) {
-          case '.js':
-          case '.jsx':
-            formattedContent = this.formatJavaScript(content);
-            break;
-          case '.json':
-            formattedContent = this.formatJSON(content);
-            break;
-          case '.html':
-            formattedContent = this.formatHTML(content);
-            break;
-          case '.css':
-            formattedContent = this.formatCSS(content);
-            break;
-          default:
-            return res.status(400).json({ success: false, error: 'File type not supported for formatting' });
-        }
-        
-        // Write formatted content back to file
-        fs.writeFileSync(fullPath, formattedContent, 'utf8');
-        
-        res.json({ success: true, message: 'File formatted successfully' });
-        
-      } catch (error) {
-        res.status(500).json({ success: false, error: error.message });
-      }
-    });
+    this.app.use('/api', createFileRoutes(this.fileService));
+    this.app.use('/api/execute', createExecuteRoutes(this.pythonExecutor));
+    this.app.use('/api/format', createFormatRoutes(this.fileService, this.codeFormatter));
   }
 
   setupSocketHandlers() {
     this.io.on('connection', (socket) => {
       console.log('Client connected');
-      
-      socket.on('disconnect', () => {
-        console.log('Client disconnected');
-      });
-
-      // Send initial file list
-      socket.emit('fileTree', this.getFileTree(this.watchDir));
+      socket.on('disconnect', () => console.log('Client disconnected'));
+      socket.emit('fileTree', this.fileService.getFileTree());
     });
   }
 
   setupFileWatcher() {
-    this.watcher = chokidar.watch(this.watchDir, {
-      ignored: /node_modules|\.git|\.DS_Store/,
-      persistent: true,
-      ignoreInitial: true
+    this.fileWatcher.watch((event, filePath) => {
+      console.log(`File ${event}: ${filePath}`);
+
+      this.io.emit('fileChange', {
+        event,
+        path: filePath,
+        relativePath: path.relative(this.watchDir, filePath),
+        content: event !== 'unlink' ? this.fileService.readFileIfExists(filePath) : null
+      });
+
+      this.io.emit('fileTree', this.fileService.getFileTree());
     });
-
-    this.watcher
-      .on('add', (filePath) => this.handleFileChange('add', filePath))
-      .on('change', (filePath) => this.handleFileChange('change', filePath))
-      .on('unlink', (filePath) => this.handleFileChange('unlink', filePath));
-  }
-
-  handleFileChange(event, filePath) {
-    console.log(`File ${event}: ${filePath}`);
-    
-    // Emit file change to all connected clients
-    this.io.emit('fileChange', {
-      event,
-      path: filePath,
-      relativePath: path.relative(this.watchDir, filePath),
-      content: event !== 'unlink' ? this.readFileIfExists(filePath) : null
-    });
-
-    // Update file tree
-    this.io.emit('fileTree', this.getFileTree(this.watchDir));
-  }
-
-  readFileIfExists(filePath) {
-    try {
-      return fs.readFileSync(filePath, 'utf8');
-    } catch (error) {
-      return null;
-    }
-  }
-
-  getFileTree(dir, prefix = '') {
-    const items = [];
-    
-    try {
-      const files = fs.readdirSync(dir);
-      
-      for (const file of files) {
-        if (file.startsWith('.') && !file.endsWith('.html')) continue;
-        if (file === 'node_modules') continue;
-        
-        const fullPath = path.join(dir, file);
-        const relativePath = path.join(prefix, file);
-        const stat = fs.statSync(fullPath);
-        
-        if (stat.isDirectory()) {
-          items.push({
-            name: file,
-            type: 'directory',
-            path: relativePath,
-            children: this.getFileTree(fullPath, relativePath)
-          });
-        } else {
-          items.push({
-            name: file,
-            type: 'file',
-            path: relativePath,
-            extension: path.extname(file).toLowerCase(),
-            size: stat.size
-          });
-        }
-      }
-    } catch (error) {
-      console.error('Error reading directory:', error);
-    }
-    
-    return items.sort((a, b) => {
-      if (a.type === b.type) return a.name.localeCompare(b.name);
-      return a.type === 'directory' ? -1 : 1;
-    });
-  }
-
-  // Formatting methods
-  formatJavaScript(content) {
-    // Basic JavaScript/JSX formatting
-    let formatted = content
-      // Add spacing around operators
-      .replace(/([^=!<>])=([^=])/g, '$1 = $2')
-      .replace(/([^=!<>])==([^=])/g, '$1 == $2')
-      .replace(/([^=!<>])===([^=])/g, '$1 === $2')
-      // Add spacing around braces
-      .replace(/\{([^\s])/g, '{ $1')
-      .replace(/([^\s])\}/g, '$1 }')
-      // Fix indentation (basic)
-      .split('\n')
-      .map(line => line.trim())
-      .map((line, i, arr) => {
-        let indent = 0;
-        for (let j = 0; j < i; j++) {
-          const prevLine = arr[j];
-          if (prevLine.includes('{')) indent += 2;
-          if (prevLine.includes('}')) indent -= 2;
-        }
-        if (line.includes('}')) indent -= 2;
-        return ' '.repeat(Math.max(0, indent)) + line;
-      })
-      .join('\n');
-    
-    return formatted;
-  }
-
-  formatJSON(content) {
-    try {
-      const parsed = JSON.parse(content);
-      return JSON.stringify(parsed, null, 2);
-    } catch (error) {
-      throw new Error('Invalid JSON content');
-    }
-  }
-
-  formatHTML(content) {
-    // Basic HTML formatting
-    let formatted = content
-      // Add newlines after tags
-      .replace(/></g, '>\n<')
-      // Fix indentation
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0)
-      .map((line, i, arr) => {
-        let indent = 0;
-        for (let j = 0; j < i; j++) {
-          const prevLine = arr[j];
-          if (prevLine.match(/<[^\/][^>]*[^\/]>/)) indent += 2;
-          if (prevLine.match(/<\/[^>]*>/)) indent -= 2;
-        }
-        if (line.match(/<\/[^>]*>/)) indent -= 2;
-        return ' '.repeat(Math.max(0, indent)) + line;
-      })
-      .join('\n');
-    
-    return formatted;
-  }
-
-  formatCSS(content) {
-    // Basic CSS formatting
-    let formatted = content
-      // Add spacing around braces
-      .replace(/\{/g, ' {\n  ')
-      .replace(/\}/g, '\n}\n')
-      // Add spacing after colons
-      .replace(/:\s*([^;]+);/g, ': $1;')
-      // Add newlines after semicolons
-      .replace(/;\s*([^}])/g, ';\n  $1')
-      // Clean up multiple newlines
-      .replace(/\n\s*\n/g, '\n')
-      .trim();
-    
-    return formatted;
   }
 
   start() {
     this.server.listen(this.port, () => {
       console.log(`🚀 QuickView Server running at http://localhost:${this.port}`);
       console.log(`📁 Watching directory: ${this.watchDir}`);
-      
       console.log('💡 Open http://localhost:' + this.port + ' in your browser');
     });
   }
 
   stop() {
-    if (this.watcher) {
-      this.watcher.close();
-    }
+    this.fileWatcher.stop();
     this.server.close();
   }
 }
 
-// Export for use as module or run directly
 if (require.main === module) {
   const server = new QuickViewServer({
     port: process.env.PORT || 3333,
     watchDir: process.argv[2] || process.cwd()
   });
-  
+
   server.start();
 
-  // Graceful shutdown
   process.on('SIGINT', () => {
     console.log('\n🛑 Shutting down QuickView Server...');
     server.stop();

--- a/quickview-tool/src/routes/execute-routes.js
+++ b/quickview-tool/src/routes/execute-routes.js
@@ -1,0 +1,49 @@
+const express = require('express');
+
+function createExecuteRoutes(pythonExecutor) {
+  const router = express.Router();
+
+  router.post('/python', async (req, res) => {
+    const { code, filename } = req.body;
+    const clientIP = req.ip || req.connection.remoteAddress || 'unknown';
+
+    if (pythonExecutor.isRateLimited(clientIP)) {
+      return res.status(429).json({
+        error: 'Too many Python executions. Please wait a minute before trying again.',
+        success: false
+      });
+    }
+
+    const validation = pythonExecutor.validateCode(code);
+    if (!validation.valid) {
+      return res.status(400).json({ error: validation.error, success: false });
+    }
+
+    pythonExecutor.recordExecution(clientIP);
+
+    try {
+      const result = await pythonExecutor.execute(code, filename);
+      res.json(result);
+    } catch (err) {
+      if (err.code === 'ETIMEDOUT') {
+        res.status(408).json({
+          success: false,
+          error: 'Python script execution timed out (30 second limit)',
+          output: '',
+          exitCode: -1
+        });
+      } else {
+        res.status(500).json({
+          success: false,
+          error: 'Failed to execute Python script: ' + err.message,
+          output: '',
+          exitCode: -1
+        });
+      }
+    }
+  });
+
+  return router;
+}
+
+module.exports = createExecuteRoutes;

--- a/quickview-tool/src/routes/file-routes.js
+++ b/quickview-tool/src/routes/file-routes.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const path = require('path');
+
+function createFileRoutes(fileService) {
+  const router = express.Router();
+
+  router.get('/file/*', (req, res) => {
+    const requestedPath = req.params[0];
+    const filename = path.basename(requestedPath);
+
+    if (fileService.isHiddenFile(filename)) {
+      return res.status(403).json({ error: 'Access to hidden files denied' });
+    }
+
+    const ext = path.extname(filename).toLowerCase();
+    if (ext && !fileService.isAllowedExtension(ext)) {
+      return res.status(403).json({ error: 'File type not supported for security reasons' });
+    }
+
+    const filePath = fileService.getFilePath(requestedPath);
+
+    if (!fileService.fileExists(filePath)) {
+      return res.status(404).json({ error: 'File not found' });
+    }
+
+    try {
+      const content = fileService.readFile(filePath);
+      res.json({ content, extension: ext, filename, path: requestedPath });
+    } catch {
+      res.status(500).json({ error: 'Unable to read file' });
+    }
+  });
+
+  router.get('/files', (req, res) => {
+    res.json(fileService.getFileTree());
+  });
+
+  return router;
+}
+
+module.exports = createFileRoutes;

--- a/quickview-tool/src/routes/format-routes.js
+++ b/quickview-tool/src/routes/format-routes.js
@@ -1,0 +1,32 @@
+const express = require('express');
+
+function createFormatRoutes(fileService, codeFormatter) {
+  const router = express.Router();
+
+  router.post('/', (req, res) => {
+    const { filepath, extension } = req.body;
+
+    if (!filepath || !extension) {
+      return res.status(400).json({ success: false, error: 'Missing filepath or extension' });
+    }
+
+    const fullPath = fileService.getFilePath(filepath);
+
+    try {
+      const content = fileService.readFile(fullPath);
+      const formatted = codeFormatter.format(content, extension);
+      fileService.writeFile(fullPath, formatted);
+      res.json({ success: true, message: 'File formatted successfully' });
+    } catch (error) {
+      if (error.message === 'File type not supported for formatting') {
+        res.status(400).json({ success: false, error: error.message });
+      } else {
+        res.status(500).json({ success: false, error: error.message });
+      }
+    }
+  });
+
+  return router;
+}
+
+module.exports = createFormatRoutes;

--- a/quickview-tool/src/services/code-formatter.js
+++ b/quickview-tool/src/services/code-formatter.js
@@ -1,0 +1,78 @@
+class CodeFormatter {
+  formatJavaScript(content) {
+    return content
+      .replace(/([^=!<>])=([^=])/g, '$1 = $2')
+      .replace(/([^=!<>])==([^=])/g, '$1 == $2')
+      .replace(/([^=!<>])===([^=])/g, '$1 === $2')
+      .replace(/\{([^\s])/g, '{ $1')
+      .replace(/([^\s])\}/g, '$1 }')
+      .split('\n')
+      .map(line => line.trim())
+      .map((line, i, arr) => {
+        let indent = 0;
+        for (let j = 0; j < i; j++) {
+          const prevLine = arr[j];
+          if (prevLine.includes('{')) indent += 2;
+          if (prevLine.includes('}')) indent -= 2;
+        }
+        if (line.includes('}')) indent -= 2;
+        return ' '.repeat(Math.max(0, indent)) + line;
+      })
+      .join('\n');
+  }
+
+  formatJSON(content) {
+    try {
+      return JSON.stringify(JSON.parse(content), null, 2);
+    } catch {
+      throw new Error('Invalid JSON content');
+    }
+  }
+
+  formatHTML(content) {
+    return content
+      .replace(/></g, '>\n<')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+      .map((line, i, arr) => {
+        let indent = 0;
+        for (let j = 0; j < i; j++) {
+          const prevLine = arr[j];
+          if (prevLine.match(/<[^\/][^>]*[^\/]>/)) indent += 2;
+          if (prevLine.match(/<\/[^>]*>/)) indent -= 2;
+        }
+        if (line.match(/<\/[^>]*>/)) indent -= 2;
+        return ' '.repeat(Math.max(0, indent)) + line;
+      })
+      .join('\n');
+  }
+
+  formatCSS(content) {
+    return content
+      .replace(/\{/g, ' {\n  ')
+      .replace(/\}/g, '\n}\n')
+      .replace(/:\s*([^;]+);/g, ': $1;')
+      .replace(/;\s*([^}])/g, ';\n  $1')
+      .replace(/\n\s*\n/g, '\n')
+      .trim();
+  }
+
+  format(content, extension) {
+    switch (extension) {
+      case '.js':
+      case '.jsx':
+        return this.formatJavaScript(content);
+      case '.json':
+        return this.formatJSON(content);
+      case '.html':
+        return this.formatHTML(content);
+      case '.css':
+        return this.formatCSS(content);
+      default:
+        throw new Error('File type not supported for formatting');
+    }
+  }
+}
+
+module.exports = CodeFormatter;

--- a/quickview-tool/src/services/file-service.js
+++ b/quickview-tool/src/services/file-service.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const fs = require('fs');
+
+const ALLOWED_EXTENSIONS = [
+  '.html', '.jsx', '.js', '.py', '.css', '.json',
+  '.md', '.svg', '.txt', '.xml', '.yaml', '.yml'
+];
+
+class FileService {
+  constructor(watchDir) {
+    this.watchDir = watchDir;
+  }
+
+  isAllowedExtension(ext) {
+    return !ext || ALLOWED_EXTENSIONS.includes(ext);
+  }
+
+  isHiddenFile(filename) {
+    return filename.startsWith('.') && !filename.endsWith('.html');
+  }
+
+  getFilePath(requestedPath) {
+    return path.join(this.watchDir, requestedPath);
+  }
+
+  readFile(filePath) {
+    return fs.readFileSync(filePath, 'utf8');
+  }
+
+  readFileIfExists(filePath) {
+    try {
+      return fs.readFileSync(filePath, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  writeFile(filePath, content) {
+    fs.writeFileSync(filePath, content, 'utf8');
+  }
+
+  fileExists(filePath) {
+    return fs.existsSync(filePath);
+  }
+
+  getFileTree(dir = this.watchDir, prefix = '') {
+    const items = [];
+
+    try {
+      const files = fs.readdirSync(dir);
+
+      for (const file of files) {
+        if (file.startsWith('.') && !file.endsWith('.html')) continue;
+        if (file === 'node_modules') continue;
+
+        const fullPath = path.join(dir, file);
+        const relativePath = path.join(prefix, file);
+        const stat = fs.statSync(fullPath);
+
+        if (stat.isDirectory()) {
+          items.push({
+            name: file,
+            type: 'directory',
+            path: relativePath,
+            children: this.getFileTree(fullPath, relativePath)
+          });
+        } else {
+          items.push({
+            name: file,
+            type: 'file',
+            path: relativePath,
+            extension: path.extname(file).toLowerCase(),
+            size: stat.size
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Error reading directory:', error);
+    }
+
+    return items.sort((a, b) => {
+      if (a.type === b.type) return a.name.localeCompare(b.name);
+      return a.type === 'directory' ? -1 : 1;
+    });
+  }
+}
+
+module.exports = FileService;

--- a/quickview-tool/src/services/file-watcher.js
+++ b/quickview-tool/src/services/file-watcher.js
@@ -1,0 +1,29 @@
+const chokidar = require('chokidar');
+
+class FileWatcher {
+  constructor(watchDir) {
+    this.watchDir = watchDir;
+    this.watcher = null;
+  }
+
+  watch(onChange) {
+    this.watcher = chokidar.watch(this.watchDir, {
+      ignored: /node_modules|\.git|\.DS_Store/,
+      persistent: true,
+      ignoreInitial: true
+    });
+
+    this.watcher
+      .on('add', (filePath) => onChange('add', filePath))
+      .on('change', (filePath) => onChange('change', filePath))
+      .on('unlink', (filePath) => onChange('unlink', filePath));
+  }
+
+  stop() {
+    if (this.watcher) {
+      this.watcher.close();
+    }
+  }
+}
+
+module.exports = FileWatcher;

--- a/quickview-tool/src/services/python-executor.js
+++ b/quickview-tool/src/services/python-executor.js
@@ -1,0 +1,85 @@
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const RATE_LIMIT_COUNT = 5;
+const RATE_LIMIT_WINDOW = 60000; // 1 minute
+const TIMEOUT = 30000; // 30 seconds
+const MAX_CODE_SIZE = 50000; // 50KB
+const TEMP_DIR = path.join(__dirname, '../../temp');
+
+class PythonExecutor {
+  constructor() {
+    this.executionCount = new Map();
+  }
+
+  isRateLimited(clientIP) {
+    const now = Date.now();
+    const executions = this.executionCount.get(clientIP) || [];
+    const recent = executions.filter(t => now - t < RATE_LIMIT_WINDOW);
+    return recent.length >= RATE_LIMIT_COUNT;
+  }
+
+  recordExecution(clientIP) {
+    const now = Date.now();
+    const executions = this.executionCount.get(clientIP) || [];
+    const recent = executions.filter(t => now - t < RATE_LIMIT_WINDOW);
+    recent.push(now);
+    this.executionCount.set(clientIP, recent);
+  }
+
+  validateCode(code) {
+    if (!code || typeof code !== 'string') {
+      return { valid: false, error: 'Invalid Python code provided' };
+    }
+    if (code.length > MAX_CODE_SIZE) {
+      return { valid: false, error: 'Python code too large (max 50KB)' };
+    }
+    return { valid: true };
+  }
+
+  execute(code, filename) {
+    return new Promise((resolve, reject) => {
+      if (!fs.existsSync(TEMP_DIR)) {
+        fs.mkdirSync(TEMP_DIR, { recursive: true });
+      }
+
+      const tempFile = path.join(TEMP_DIR, `${filename || 'temp'}_${Date.now()}.py`);
+
+      try {
+        fs.writeFileSync(tempFile, code);
+      } catch (error) {
+        return reject(new Error('Failed to create temp file'));
+      }
+
+      const python = spawn('python3', [tempFile], {
+        timeout: TIMEOUT,
+        killSignal: 'SIGKILL'
+      });
+
+      let output = '';
+      let error = '';
+
+      python.stdout.on('data', (data) => { output += data.toString(); });
+      python.stderr.on('data', (data) => { error += data.toString(); });
+
+      const cleanup = () => {
+        try { fs.unlinkSync(tempFile); } catch {
+          console.warn('Failed to clean up temp file:', tempFile);
+        }
+      };
+
+      python.on('close', (code) => {
+        cleanup();
+        resolve({ success: code === 0, output, error, exitCode: code });
+      });
+
+      python.on('error', (err) => {
+        cleanup();
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = PythonExecutor;


### PR DESCRIPTION
Decomposes the two monolithic files into focused, single-responsibility modules for easier maintenance and extensibility.

Server-side: FileService, PythonExecutor, CodeFormatter, FileWatcher, and three route modules.

Client-side: Six renderer ES modules, three manager classes, and a shared utils module.

Closes #24

Generated with [Claude Code](https://claude.ai/code)