### PR TITLE
Update package name to clawdview and author info

### DIFF
--- a/quickview-tool/package.json
+++ b/quickview-tool/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quickview-tool",
+  "name": "clawdview",
   "version": "1.0.0",
   "description": "Universal rapid prototyping tool for instant code preview",
   "main": "server.js",
@@ -32,6 +32,6 @@
     "development",
     "hot-reload"
   ],
-  "author": "Austin Morrissey",
+  "author": "Andrew Hopper",
   "license": "MIT"
 }


### PR DESCRIPTION
Updates the npm publishing configuration in `quickview-tool/package.json`:
- Package name changed from `quickview-tool` to `clawdview`
- Author updated from `Austin Morrissey` to `Andrew Hopper`

Fixes #23

Generated with [Claude Code](https://claude.ai/code)