### PR TITLE
feat: add modular renderer system for preview pane (#13)

### DIFF
--- a/quickview-tool/public/app.js
+++ b/quickview-tool/public/app.js
@@ -120,7 +120,11 @@ class QuickViewApp {
             'json': 'json',
             'md': 'md',
             'svg': 'svg',
-            'css': 'css'
+            'css': 'css',
+            'yaml': 'yaml',
+            'yml': 'yaml',
+            'mmd': 'mermaid',
+            'mermaid': 'mermaid'
         };
         
         return classMap[ext] || 'file';
@@ -192,151 +196,21 @@ class QuickViewApp {
             '.css': 'css',
             '.json': 'json',
             '.md': 'markdown',
-            '.svg': 'xml'
+            '.svg': 'xml',
+            '.yaml': 'yaml',
+            '.yml': 'yaml',
+            '.mmd': 'plaintext',
+            '.mermaid': 'plaintext'
         };
-        
+
         return langMap[extension] || null;
     }
 
     updatePreviewPanel(content, extension, filename) {
         const previewContent = document.getElementById('preview-content');
-        
-        switch (extension) {
-            case '.html':
-                this.renderHTML(previewContent, content);
-                break;
-                
-            case '.jsx':
-                this.renderReact(previewContent, content);
-                break;
-                
-            case '.py':
-                this.renderPythonPreview(previewContent, content, filename);
-                break;
-                
-            case '.svg':
-                this.renderSVG(previewContent, content);
-                break;
-                
-            case '.md':
-                this.renderMarkdown(previewContent, content);
-                break;
-                
-            case '.json':
-                this.renderJSON(previewContent, content);
-                break;
-                
-            default:
-                this.renderText(previewContent, content);
-        }
-    }
-
-    renderHTML(container, content) {
-        const iframe = document.createElement('iframe');
-        iframe.className = 'preview-iframe';
-        iframe.srcdoc = content;
-        
-        container.innerHTML = '';
-        container.appendChild(iframe);
-    }
-
-    renderReact(container, content) {
-        try {
-            // Create a wrapper for React component
-            const wrapper = document.createElement('div');
-            wrapper.id = 'react-preview';
-            container.innerHTML = '';
-            container.appendChild(wrapper);
-            
-            // Transform JSX using Babel
-            const transformed = Babel.transform(content, {
-                presets: ['react']
-            }).code;
-            
-            // Create and execute the component
-            const script = document.createElement('script');
-            script.textContent = `
-                try {
-                    ${transformed}
-                    
-                    // Try to find and render the component
-                    const componentName = Object.keys(window).find(key => 
-                        typeof window[key] === 'function' && 
-                        key[0] === key[0].toUpperCase()
-                    );
-                    
-                    if (componentName) {
-                        const Component = window[componentName];
-                        ReactDOM.render(React.createElement(Component), document.getElementById('react-preview'));
-                    }
-                } catch (error) {
-                    document.getElementById('react-preview').innerHTML = 
-                        '<div class="error">React Error: ' + error.message + '</div>';
-                }
-            `;
-            
-            document.head.appendChild(script);
-            setTimeout(() => document.head.removeChild(script), 100);
-            
-        } catch (error) {
-            container.innerHTML = `<div class="error">Failed to render React component: ${error.message}</div>`;
-        }
-    }
-
-    renderPythonPreview(container, content, filename) {
-        container.innerHTML = `
-            <div style="padding: 20px; color: #333;">
-                <h3>Python Script: ${filename}</h3>
-                <p>Click "Run" to execute this Python script and see the output.</p>
-                <div style="margin-top: 20px; padding: 15px; background: #f5f5f5; border-radius: 6px;">
-                    <strong>Script Preview:</strong>
-                    <pre style="margin-top: 10px; overflow-x: auto;">${this.escapeHtml(content.substring(0, 500))}${content.length > 500 ? '...' : ''}</pre>
-                </div>
-            </div>
-        `;
-    }
-
-    renderSVG(container, content) {
-        container.innerHTML = `
-            <div style="padding: 20px; text-align: center; background: white;">
-                ${content}
-            </div>
-        `;
-    }
-
-    renderMarkdown(container, content) {
-        // Simple markdown rendering (would use marked.js in production)
-        const html = content
-            .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-            .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-            .replace(/^### (.*$)/gim, '<h3>$1</h3>')
-            .replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>')
-            .replace(/\*(.*)\*/gim, '<em>$1</em>')
-            .replace(/\n/gim, '<br>');
-            
-        container.innerHTML = `<div style="padding: 20px; color: #333;">${html}</div>`;
-    }
-
-    renderJSON(container, content) {
-        try {
-            const parsed = JSON.parse(content);
-            const formatted = JSON.stringify(parsed, null, 2);
-            container.innerHTML = `
-                <div style="padding: 20px; color: #333;">
-                    <pre style="background: #f5f5f5; padding: 15px; border-radius: 6px; overflow-x: auto;">${this.escapeHtml(formatted)}</pre>
-                </div>
-            `;
-        } catch (error) {
-            container.innerHTML = `<div class="error">Invalid JSON: ${error.message}</div>`;
-        }
-    }
-
-    renderText(container, content) {
-        container.innerHTML = `
-            <div style="padding: 20px; color: #333;">
-                <pre style="white-space: pre-wrap; font-family: monospace;">${this.escapeHtml(content)}</pre>
-            </div>
-        `;
+        // Delegate to the modular renderer registry.
+        // To add a new renderer: create a file in public/renderers/ and add a <script> tag in index.html.
+        window.RendererRegistry.render(previewContent, content, extension, filename);
     }
 
     updateActionButtons(extension) {

--- a/quickview-tool/public/index.html
+++ b/quickview-tool/public/index.html
@@ -62,7 +62,33 @@
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <!-- marked.js for Markdown rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/marked@5/marked.min.js"></script>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        // Initialise Mermaid with a dark theme to match the app
+        if (window.mermaid) {
+            mermaid.initialize({
+                startOnLoad: false,
+                theme: 'dark',
+                securityLevel: 'loose',
+                fontFamily: 'Inter, system-ui, sans-serif'
+            });
+        }
+    </script>
     <link rel="stylesheet" href="style.css">
+    <!-- Renderer modules — registry must be first, text (fallback) must be last -->
+    <script src="renderers/registry.js"></script>
+    <script src="renderers/html-renderer.js"></script>
+    <script src="renderers/react-renderer.js"></script>
+    <script src="renderers/svg-renderer.js"></script>
+    <script src="renderers/json-renderer.js"></script>
+    <script src="renderers/mermaid-renderer.js"></script>
+    <script src="renderers/markdown-renderer.js"></script>
+    <script src="renderers/python-renderer.js"></script>
+    <script src="renderers/yaml-renderer.js"></script>
+    <script src="renderers/text-renderer.js"></script>
 </head>
 <body class="bg-background text-foreground h-screen overflow-hidden font-sans">
     <div class="flex flex-col h-screen">
@@ -103,8 +129,10 @@
                                         <li class="text-sm text-gray-600">⚛️ React Components (JSX)</li>
                                         <li class="text-sm text-gray-600">🐍 Python Scripts</li>
                                         <li class="text-sm text-gray-600">🎨 SVG Graphics</li>
-                                        <li class="text-sm text-gray-600">📝 Markdown</li>
-                                        <li class="text-sm text-gray-600">📊 JSON/YAML</li>
+                                        <li class="text-sm text-gray-600">📝 Markdown (+ Mermaid diagrams)</li>
+                                        <li class="text-sm text-gray-600">📊 JSON (interactive tree view)</li>
+                                        <li class="text-sm text-gray-600">📄 YAML/YML</li>
+                                        <li class="text-sm text-gray-600">🔀 Mermaid diagrams (.mmd)</li>
                                     </ul>
                                 </div>
                             </div>

--- a/quickview-tool/public/renderers/html-renderer.js
+++ b/quickview-tool/public/renderers/html-renderer.js
@@ -1,0 +1,16 @@
+/**
+ * HTML Renderer — renders .html files in a sandboxed iframe.
+ */
+RendererRegistry.register({
+  name: 'html',
+  extensions: ['.html'],
+  priority: 10,
+
+  render(container, content) {
+    const iframe = document.createElement('iframe');
+    iframe.className = 'preview-iframe';
+    iframe.srcdoc = content;
+    container.innerHTML = '';
+    container.appendChild(iframe);
+  }
+});

--- a/quickview-tool/public/renderers/json-renderer.js
+++ b/quickview-tool/public/renderers/json-renderer.js
@@ -1,0 +1,128 @@
+/**
+ * JSON Renderer — renders JSON as an interactive, collapsible tree view.
+ * Click the ▾/▸ toggle to expand or collapse objects and arrays.
+ */
+RendererRegistry.register({
+  name: 'json',
+  extensions: ['.json'],
+  priority: 10,
+
+  render(container, content) {
+    let parsed;
+    try {
+      parsed = JSON.parse(content);
+    } catch (err) {
+      container.innerHTML = `<div class="error">Invalid JSON: ${this._escapeHtml(err.message)}</div>`;
+      return;
+    }
+
+    container.innerHTML = '';
+    const viewer = document.createElement('div');
+    viewer.className = 'json-viewer';
+    viewer.appendChild(this._buildNode(parsed, null, true));
+    container.appendChild(viewer);
+  },
+
+  /**
+   * Recursively build a DOM node for a JSON value.
+   * @param {*} value — the JSON value
+   * @param {string|number|null} key — the key for this value, or null if root
+   * @param {boolean} isRoot — whether this is the top-level call
+   */
+  _buildNode(value, key, isRoot) {
+    const type = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+    const row = document.createElement('div');
+    row.className = 'jv-row';
+
+    // Render the key label (skip for root)
+    if (key !== null) {
+      const keyEl = document.createElement('span');
+      keyEl.className = 'jv-key';
+      keyEl.textContent = JSON.stringify(key) + ': ';
+      row.appendChild(keyEl);
+    }
+
+    if (type === 'null') {
+      const val = document.createElement('span');
+      val.className = 'jv-null';
+      val.textContent = 'null';
+      row.appendChild(val);
+      return row;
+    }
+
+    if (type === 'object' || type === 'array') {
+      const entries = type === 'array'
+        ? value.map((v, i) => [i, v])
+        : Object.entries(value);
+      const count = entries.length;
+      const brackets = type === 'array' ? ['[', ']'] : ['{', '}'];
+
+      // Build summary for collapsed state
+      const previewKeys = type === 'array'
+        ? `Array(${count})`
+        : `{ ${Object.keys(value).slice(0, 3).map(k => JSON.stringify(k)).join(', ')}${count > 3 ? ', …' : ''} }`;
+
+      const toggle = document.createElement('span');
+      toggle.className = 'jv-toggle';
+      toggle.textContent = '▾';
+      toggle.title = 'Click to collapse/expand';
+
+      const openBracket = document.createElement('span');
+      openBracket.className = 'jv-bracket';
+      openBracket.textContent = brackets[0];
+
+      const summary = document.createElement('span');
+      summary.className = 'jv-summary';
+      summary.textContent = ' ' + previewKeys;
+      summary.style.display = 'none';
+
+      const children = document.createElement('div');
+      children.className = 'jv-children';
+
+      entries.forEach(([k, v]) => {
+        children.appendChild(this._buildNode(v, k, false));
+      });
+
+      const closeRow = document.createElement('div');
+      closeRow.className = 'jv-row jv-close-row';
+      const closeBracket = document.createElement('span');
+      closeBracket.className = 'jv-bracket';
+      closeBracket.textContent = brackets[1];
+      closeRow.appendChild(closeBracket);
+
+      // Count badge
+      const badge = document.createElement('span');
+      badge.className = 'jv-count';
+      badge.textContent = ` // ${count} ${type === 'array' ? 'item' : 'key'}${count !== 1 ? 's' : ''}`;
+      openBracket.appendChild(badge);
+
+      toggle.addEventListener('click', () => {
+        const isCollapsed = children.style.display === 'none';
+        children.style.display = isCollapsed ? '' : 'none';
+        closeRow.style.display = isCollapsed ? '' : 'none';
+        summary.style.display = isCollapsed ? 'none' : '';
+        toggle.textContent = isCollapsed ? '▾' : '▸';
+      });
+
+      row.appendChild(toggle);
+      row.appendChild(openBracket);
+      row.appendChild(summary);
+      row.appendChild(children);
+      row.appendChild(closeRow);
+    } else {
+      // Primitive value
+      const val = document.createElement('span');
+      val.className = `jv-${type}`;
+      val.textContent = JSON.stringify(value);
+      row.appendChild(val);
+    }
+
+    return row;
+  },
+
+  _escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = String(text);
+    return d.innerHTML;
+  }
+});

--- a/quickview-tool/public/renderers/markdown-renderer.js
+++ b/quickview-tool/public/renderers/markdown-renderer.js
@@ -1,0 +1,105 @@
+/**
+ * Markdown Renderer — renders .md files with full GFM support.
+ *
+ * Uses marked.js for parsing (loaded via CDN).
+ * Applies highlight.js syntax highlighting to fenced code blocks.
+ * Detects ```mermaid code blocks and renders them as diagrams if Mermaid.js is available.
+ */
+RendererRegistry.register({
+  name: 'markdown',
+  extensions: ['.md'],
+  priority: 10,
+
+  render(container, content) {
+    let html;
+
+    if (window.marked) {
+      // Configure marked with highlight.js integration
+      const options = {
+        breaks: true,
+        gfm: true
+      };
+
+      if (window.hljs) {
+        options.highlight = (code, lang) => {
+          // Don't highlight mermaid blocks — we'll render them as diagrams
+          if (lang === 'mermaid') return code;
+          if (lang && hljs.getLanguage(lang)) {
+            return hljs.highlight(code, { language: lang }).value;
+          }
+          return hljs.highlightAuto(code).value;
+        };
+      }
+
+      marked.setOptions(options);
+      html = marked.parse(content);
+    } else {
+      // Basic fallback if marked isn't available
+      html = this._basicMarkdown(content);
+    }
+
+    container.innerHTML = '';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'markdown-body';
+    wrapper.innerHTML = html;
+    container.appendChild(wrapper);
+
+    // Convert ```mermaid blocks into rendered diagrams
+    if (window.mermaid) {
+      const mermaidBlocks = [];
+      wrapper.querySelectorAll('pre > code.language-mermaid, code.language-mermaid').forEach(codeEl => {
+        const diagramText = codeEl.textContent.trim();
+        const diagramEl = document.createElement('div');
+        diagramEl.className = 'mermaid';
+        diagramEl.textContent = diagramText;
+
+        const pre = codeEl.closest('pre');
+        if (pre) {
+          pre.replaceWith(diagramEl);
+        } else {
+          codeEl.replaceWith(diagramEl);
+        }
+        mermaidBlocks.push(diagramEl);
+      });
+
+      if (mermaidBlocks.length > 0) {
+        try {
+          if (typeof mermaid.run === 'function') {
+            mermaid.run({ nodes: mermaidBlocks });
+          } else {
+            mermaid.init(undefined, mermaidBlocks);
+          }
+        } catch (err) {
+          console.warn('[markdown-renderer] Mermaid render error:', err);
+        }
+      }
+    }
+
+    // Apply syntax highlighting to remaining code blocks
+    if (window.hljs) {
+      wrapper.querySelectorAll('pre code:not(.language-mermaid)').forEach(block => {
+        hljs.highlightElement(block);
+      });
+    }
+  },
+
+  /** Minimal Markdown fallback (no marked.js) */
+  _basicMarkdown(content) {
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    return escaped
+      .replace(/^###### (.*$)/gim, '<h6>$1</h6>')
+      .replace(/^##### (.*$)/gim, '<h5>$1</h5>')
+      .replace(/^#### (.*$)/gim, '<h4>$1</h4>')
+      .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+      .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+      .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+      .replace(/\*\*([^*]+)\*\*/gim, '<strong>$1</strong>')
+      .replace(/\*([^*]+)\*/gim, '<em>$1</em>')
+      .replace(/`([^`]+)`/gim, '<code>$1</code>')
+      .replace(/\n/gim, '<br>');
+  }
+});

--- a/quickview-tool/public/renderers/mermaid-renderer.js
+++ b/quickview-tool/public/renderers/mermaid-renderer.js
@@ -1,0 +1,53 @@
+/**
+ * Mermaid Renderer — renders Mermaid diagram syntax (.mmd / .mermaid files).
+ *
+ * Requires Mermaid.js to be loaded before this script.
+ * For Mermaid diagrams inside Markdown files, see markdown-renderer.js.
+ */
+RendererRegistry.register({
+  name: 'mermaid',
+  extensions: ['.mmd', '.mermaid'],
+  priority: 10,
+
+  render(container, content) {
+    if (!window.mermaid) {
+      container.innerHTML = '<div class="error">Mermaid.js is not loaded — cannot render diagram.</div>';
+      return;
+    }
+
+    container.innerHTML = '';
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = [
+      'padding:20px',
+      'background:white',
+      'min-height:100%',
+      'display:flex',
+      'justify-content:center',
+      'align-items:flex-start',
+      'box-sizing:border-box'
+    ].join(';');
+
+    const diagramEl = document.createElement('div');
+    diagramEl.className = 'mermaid';
+    diagramEl.textContent = content.trim();
+    wrapper.appendChild(diagramEl);
+    container.appendChild(wrapper);
+
+    // mermaid.run() is the modern API (v10+); fall back to mermaid.init() for older versions
+    try {
+      if (typeof mermaid.run === 'function') {
+        mermaid.run({ nodes: [diagramEl] });
+      } else {
+        mermaid.init(undefined, diagramEl);
+      }
+    } catch (err) {
+      container.innerHTML = `<div class="error">Mermaid render error: ${this._escapeHtml(err.message)}</div>`;
+    }
+  },
+
+  _escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = String(text);
+    return d.innerHTML;
+  }
+});

--- a/quickview-tool/public/renderers/python-renderer.js
+++ b/quickview-tool/public/renderers/python-renderer.js
@@ -1,0 +1,45 @@
+/**
+ * Python Renderer — shows a preview of Python scripts with a "Run" prompt.
+ * Actual execution is triggered by the toolbar "Run" button in app.js.
+ */
+RendererRegistry.register({
+  name: 'python',
+  extensions: ['.py'],
+  priority: 10,
+
+  render(container, content, extension, filename) {
+    const preview = content.length > 600 ? content.substring(0, 600) + '\n...' : content;
+    const lines = content.split('\n').length;
+    const docstring = this._extractDocstring(content);
+
+    container.innerHTML = `
+      <div style="padding:20px;color:hsl(var(--foreground, #333));">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+          <span style="font-size:1.5rem;">🐍</span>
+          <div>
+            <h3 style="margin:0;font-size:0.9375rem;font-weight:600;">${this._escapeHtml(filename)}</h3>
+            <span style="font-size:0.75rem;color:#888;">${lines} lines</span>
+          </div>
+        </div>
+        ${docstring ? `<div style="padding:10px 14px;background:rgba(99,102,241,0.08);border-left:3px solid #6366f1;border-radius:4px;margin-bottom:14px;font-size:0.8125rem;color:#aaa;">${this._escapeHtml(docstring)}</div>` : ''}
+        <p style="margin:0 0 14px;font-size:0.875rem;color:#888;">
+          Click <strong style="color:hsl(var(--foreground,#eee));">▶ Run</strong> in the toolbar to execute this script.
+        </p>
+        <div style="background:hsl(220,13%,8%);border:1px solid hsl(240,3.7%,15.9%);border-radius:6px;padding:16px;overflow-x:auto;">
+          <div style="font-size:0.6875rem;text-transform:uppercase;letter-spacing:.06em;color:#555;margin-bottom:8px;">Script preview</div>
+          <pre style="margin:0;font-family:'JetBrains Mono',monospace;font-size:0.8125rem;color:#c9d1d9;white-space:pre;">${this._escapeHtml(preview)}</pre>
+        </div>
+      </div>`;
+  },
+
+  _extractDocstring(content) {
+    const match = content.match(/^(?:[\s\S]*?def\s+\w+[^)]*\):\s*\n\s*)?"""([\s\S]*?)"""/);
+    return match ? match[1].trim() : null;
+  },
+
+  _escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = String(text);
+    return d.innerHTML;
+  }
+});

--- a/quickview-tool/public/renderers/react-renderer.js
+++ b/quickview-tool/public/renderers/react-renderer.js
@@ -1,0 +1,69 @@
+/**
+ * React/JSX Renderer — transpiles JSX with Babel and renders the component.
+ */
+RendererRegistry.register({
+  name: 'react',
+  extensions: ['.jsx'],
+  priority: 10,
+
+  render(container, content) {
+    if (!window.Babel || !window.React || !window.ReactDOM) {
+      container.innerHTML = '<div class="error">React or Babel is not loaded — cannot render JSX.</div>';
+      return;
+    }
+
+    const wrapperId = 'react-preview-' + Date.now();
+    const wrapper = document.createElement('div');
+    wrapper.id = wrapperId;
+    wrapper.style.cssText = 'height:100%;padding:20px;';
+    container.innerHTML = '';
+    container.appendChild(wrapper);
+
+    let transformed;
+    try {
+      transformed = Babel.transform(content, { presets: ['react'] }).code;
+    } catch (err) {
+      container.innerHTML = `<div class="error">JSX transform error: ${this._escapeHtml(err.message)}</div>`;
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.textContent = `
+      (function() {
+        try {
+          ${transformed}
+          // Find a React component (function/class starting with uppercase)
+          const EXCLUDED = new Set(['Array','Boolean','Date','Error','Function',
+            'JSON','Math','Number','Object','RegExp','String','Symbol','Promise']);
+          const name = Object.keys(window).find(k =>
+            /^[A-Z]/.test(k) &&
+            !EXCLUDED.has(k) &&
+            typeof window[k] === 'function'
+          );
+          if (name) {
+            ReactDOM.render(
+              React.createElement(window[name]),
+              document.getElementById('${wrapperId}')
+            );
+          } else {
+            document.getElementById('${wrapperId}').innerHTML =
+              '<div class="error">No React component found. Export a function/class that starts with an uppercase letter.</div>';
+          }
+        } catch (e) {
+          const el = document.getElementById('${wrapperId}');
+          if (el) el.innerHTML = '<div class="error">React render error: ' + e.message + '</div>';
+        }
+      })();
+    `;
+    document.head.appendChild(script);
+    setTimeout(() => {
+      if (script.parentNode) script.parentNode.removeChild(script);
+    }, 200);
+  },
+
+  _escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = String(text);
+    return d.innerHTML;
+  }
+});

--- a/quickview-tool/public/renderers/registry.js
+++ b/quickview-tool/public/renderers/registry.js
@@ -1,0 +1,113 @@
+/**
+ * RendererRegistry — central registry for QuickView preview pane renderers.
+ *
+ * Each renderer object must have:
+ *   name       {string}   — unique identifier
+ *   extensions {string[]} — file extensions this renderer handles (e.g. ['.json'])
+ *                           Use ['*'] for a catch-all fallback.
+ *   render     {function(container, content, extension, filename)} — renders into the given DOM node
+ *
+ * Optional:
+ *   priority   {number}   — higher wins when multiple renderers claim the same extension (default 0)
+ *   canRender  {function(content, extension, filename) → boolean} — fine-grained eligibility check
+ *
+ * Usage:
+ *   RendererRegistry.register({ name: 'my-renderer', extensions: ['.foo'], render(container, content) { ... } });
+ *   RendererRegistry.render(container, content, '.foo', 'file.foo');
+ */
+class RendererRegistry {
+  constructor() {
+    this._renderers = [];
+  }
+
+  /**
+   * Register a renderer. Replaces any existing renderer with the same name.
+   */
+  register(renderer) {
+    if (!renderer.name || !renderer.extensions || typeof renderer.render !== 'function') {
+      throw new Error(
+        '[RendererRegistry] Renderer must have: name (string), extensions (string[]), render (function)'
+      );
+    }
+
+    // Replace existing renderer with the same name
+    this._renderers = this._renderers.filter(r => r.name !== renderer.name);
+    this._renderers.push(renderer);
+
+    // Maintain priority order (descending — highest first)
+    this._renderers.sort((a, b) => (b.priority || 0) - (a.priority || 0));
+    console.log(`[RendererRegistry] Registered renderer: "${renderer.name}" for ${renderer.extensions.join(', ')}`);
+  }
+
+  /**
+   * Find the best renderer for a given extension and content.
+   */
+  getRenderer(extension, content, filename) {
+    for (const r of this._renderers) {
+      // Skip catch-all renderers if a specific one exists for this extension
+      if (r.extensions.includes('*')) {
+        if (extension && this._hasSpecificRenderer(extension)) continue;
+      } else {
+        if (!r.extensions.includes(extension)) continue;
+      }
+      // Optional fine-grained check
+      if (typeof r.canRender === 'function' && !r.canRender(content, extension, filename)) continue;
+      return r;
+    }
+    return null;
+  }
+
+  _hasSpecificRenderer(extension) {
+    return this._renderers.some(
+      r => !r.extensions.includes('*') && r.extensions.includes(extension)
+    );
+  }
+
+  /**
+   * Render content into container using the best available renderer.
+   */
+  render(container, content, extension, filename) {
+    const renderer = this.getRenderer(extension, content, filename);
+    if (renderer) {
+      try {
+        renderer.render(container, content, extension, filename);
+      } catch (err) {
+        console.error(`[RendererRegistry] Renderer "${renderer.name}" threw:`, err);
+        this._renderError(container, `Render error in "${renderer.name}": ${err.message}`);
+      }
+    } else {
+      this._renderFallback(container, content);
+    }
+  }
+
+  _renderError(container, message) {
+    container.innerHTML = `<div class="error"><strong>Render error:</strong> ${this._escapeHtml(message)}</div>`;
+  }
+
+  _renderFallback(container, content) {
+    container.innerHTML = `
+      <div style="padding:20px;">
+        <pre style="white-space:pre-wrap;font-family:monospace;">${this._escapeHtml(content)}</pre>
+      </div>`;
+  }
+
+  _escapeHtml(text) {
+    const d = document.createElement('div');
+    d.textContent = String(text);
+    return d.innerHTML;
+  }
+
+  /**
+   * Returns a summary of all registered renderers (useful for debugging).
+   */
+  list() {
+    return this._renderers.map(r => ({
+      name: r.name,
+      extensions: r.extensions,
+      priority: r.priority || 0
+    }));
+  }
+}
+
+// Expose a single global instance
+window.RendererRegistry = new RendererRegistry();

--- a/quickview-tool/public/renderers/svg-renderer.js
+++ b/quickview-tool/public/renderers/svg-renderer.js
@@ -1,0 +1,17 @@
+/**
+ * SVG Renderer — inlines SVG content with a white centred background.
+ */
+RendererRegistry.register({
+  name: 'svg',
+  extensions: ['.svg'],
+  priority: 10,
+
+  render(container, content) {
+    // Sanitise: strip <script> tags before inlining
+    const safe = content.replace(/<script[\s\S]*?<\/script>/gi, '');
+    container.innerHTML = `
+      <div style="padding:20px;text-align:center;background:white;min-height:100%;box-sizing:border-box;">
+        ${safe}
+      </div>`;
+  }
+});

--- a/quickview-tool/public/renderers/text-renderer.js
+++ b/quickview-tool/public/renderers/text-renderer.js
@@ -1,0 +1,18 @@
+/**
+ * Text Renderer — catch-all fallback renderer for unsupported or plain-text files.
+ * Uses priority 0 so it's always last in the priority queue.
+ */
+RendererRegistry.register({
+  name: 'text',
+  extensions: ['*'],
+  priority: 0,
+
+  render(container, content) {
+    const d = document.createElement('div');
+    d.textContent = content;
+    container.innerHTML = `
+      <div style="padding:20px;min-height:100%;box-sizing:border-box;">
+        <pre style="white-space:pre-wrap;font-family:'JetBrains Mono',monospace;font-size:0.875rem;margin:0;">${d.innerHTML}</pre>
+      </div>`;
+  }
+});

--- a/quickview-tool/public/renderers/yaml-renderer.js
+++ b/quickview-tool/public/renderers/yaml-renderer.js
@@ -1,0 +1,35 @@
+/**
+ * YAML Renderer — displays YAML files with syntax highlighting.
+ * Uses highlight.js for colouring if available.
+ */
+RendererRegistry.register({
+  name: 'yaml',
+  extensions: ['.yaml', '.yml'],
+  priority: 10,
+
+  render(container, content) {
+    container.innerHTML = '';
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = 'padding:20px;min-height:100%;box-sizing:border-box;';
+
+    const pre = document.createElement('pre');
+    pre.style.cssText = 'margin:0;border-radius:6px;overflow-x:auto;';
+
+    if (window.hljs) {
+      const code = document.createElement('code');
+      code.className = 'language-yaml';
+      code.textContent = content;
+      pre.appendChild(code);
+      wrapper.appendChild(pre);
+      container.appendChild(wrapper);
+      hljs.highlightElement(code);
+    } else {
+      const code = document.createElement('code');
+      code.style.cssText = 'font-family:monospace;font-size:0.875rem;white-space:pre;';
+      code.textContent = content;
+      pre.appendChild(code);
+      wrapper.appendChild(pre);
+      container.appendChild(wrapper);
+    }
+  }
+});

--- a/quickview-tool/public/style.css
+++ b/quickview-tool/public/style.css
@@ -253,3 +253,196 @@
 ::-webkit-scrollbar-thumb:hover {
     background: hsl(var(--muted-foreground) / 0.5);
 }
+
+/* ============================================================
+   JSON Tree Viewer (json-renderer.js)
+   ============================================================ */
+.json-viewer {
+    padding: 20px;
+    font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', 'Menlo', monospace;
+    font-size: 0.8125rem;
+    line-height: 1.7;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
+    min-height: 100%;
+}
+
+.jv-row {
+    display: block;
+    padding-left: 1.25rem;
+    position: relative;
+}
+
+.jv-toggle {
+    cursor: pointer;
+    user-select: none;
+    color: hsl(var(--muted-foreground));
+    font-size: 0.6875rem;
+    margin-right: 4px;
+    display: inline-block;
+    width: 12px;
+    text-align: center;
+    transition: color 0.1s ease;
+}
+
+.jv-toggle:hover {
+    color: hsl(var(--foreground));
+}
+
+.jv-children {
+    border-left: 1px solid hsl(var(--border));
+    margin-left: 6px;
+}
+
+.jv-key     { color: hsl(210 80% 70%); }
+.jv-string  { color: hsl(142 60% 55%); }
+.jv-number  { color: hsl(30 100% 65%); }
+.jv-boolean { color: hsl(280 70% 70%); }
+.jv-null    { color: hsl(var(--muted-foreground)); font-style: italic; }
+.jv-bracket { color: hsl(var(--foreground)); }
+
+.jv-count {
+    font-size: 0.6875rem;
+    color: hsl(var(--muted-foreground));
+    margin-left: 6px;
+    font-style: italic;
+}
+
+.jv-summary {
+    color: hsl(var(--muted-foreground));
+    font-style: italic;
+    font-size: 0.75rem;
+}
+
+.jv-close-row {
+    padding-left: 0;
+}
+
+/* File tree icon for mermaid and yaml */
+.file-item.mermaid::before { content: '🔀'; font-size: 0.875rem; }
+.file-item.yaml::before    { content: '📋'; font-size: 0.875rem; }
+
+/* ============================================================
+   Markdown Preview Body (markdown-renderer.js)
+   ============================================================ */
+.markdown-body {
+    padding: 24px 32px;
+    color: hsl(var(--foreground));
+    max-width: 820px;
+    margin: 0 auto;
+    line-height: 1.75;
+    font-size: 0.9375rem;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+    margin: 1.75rem 0 0.75rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: hsl(var(--foreground));
+}
+
+.markdown-body h1 {
+    font-size: 1.875rem;
+    border-bottom: 1px solid hsl(var(--border));
+    padding-bottom: 0.5rem;
+}
+
+.markdown-body h2 {
+    font-size: 1.5rem;
+    border-bottom: 1px solid hsl(var(--border));
+    padding-bottom: 0.375rem;
+}
+
+.markdown-body h3 { font-size: 1.25rem; }
+.markdown-body h4 { font-size: 1rem; }
+
+.markdown-body p {
+    margin: 0 0 1rem;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+    margin: 0 0 1rem 1.5rem;
+}
+
+.markdown-body li {
+    margin: 0.25rem 0;
+}
+
+.markdown-body code {
+    background: hsl(var(--muted));
+    padding: 0.15em 0.4em;
+    border-radius: calc(var(--radius) - 2px);
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.875em;
+    color: hsl(30 100% 70%);
+}
+
+.markdown-body pre {
+    background: hsl(220 13% 6%);
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    padding: 16px;
+    overflow-x: auto;
+    margin: 0 0 1rem;
+}
+
+.markdown-body pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.875rem;
+    color: inherit;
+}
+
+.markdown-body blockquote {
+    border-left: 3px solid hsl(var(--border));
+    padding-left: 1rem;
+    margin: 0 0 1rem;
+    color: hsl(var(--muted-foreground));
+}
+
+.markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+    border: 1px solid hsl(var(--border));
+    padding: 6px 12px;
+    text-align: left;
+}
+
+.markdown-body th {
+    background: hsl(var(--muted));
+    font-weight: 600;
+}
+
+.markdown-body a {
+    color: hsl(210 80% 65%);
+    text-decoration: none;
+}
+
+.markdown-body a:hover {
+    text-decoration: underline;
+}
+
+.markdown-body hr {
+    border: none;
+    border-top: 1px solid hsl(var(--border));
+    margin: 1.5rem 0;
+}
+
+/* Mermaid diagrams inside markdown */
+.markdown-body .mermaid {
+    margin: 1rem 0;
+    text-align: center;
+}
+


### PR DESCRIPTION
Introduces a plugin-style RendererRegistry that replaces the monolithic switch statement in app.js. Each file type is now a self-contained renderer module in public/renderers/.

New renderers: JSON (interactive tree view), Mermaid diagrams, enhanced Markdown (with Mermaid code blocks), YAML, Python, HTML, React, SVG, and a catch-all text fallback.

Closes #13

Generated with [Claude Code](https://claude.ai/code)