### PR TITLE
feat: add Mermaid renderer for preview pane

### DIFF
--- a/quickview-tool/public/app.js
+++ b/quickview-tool/public/app.js
@@ -3,9 +3,16 @@ class QuickViewApp {
         this.socket = io();
         this.currentFile = null;
         this.fileTree = null;
+        this.setupMermaid();
         this.setupSocketHandlers();
         this.setupUIHandlers();
         this.setupTabs();
+    }
+
+    setupMermaid() {
+        if (window.mermaid) {
+            mermaid.initialize({ startOnLoad: false, theme: 'default' });
+        }
     }
 
     setupSocketHandlers() {
@@ -120,7 +127,8 @@ class QuickViewApp {
             'json': 'json',
             'md': 'md',
             'svg': 'svg',
-            'css': 'css'
+            'css': 'css',
+            'mmd': 'svg'
         };
         
         return classMap[ext] || 'file';
@@ -192,7 +200,8 @@ class QuickViewApp {
             '.css': 'css',
             '.json': 'json',
             '.md': 'markdown',
-            '.svg': 'xml'
+            '.svg': 'xml',
+            '.mmd': null
         };
         
         return langMap[extension] || null;
@@ -221,7 +230,11 @@ class QuickViewApp {
             case '.md':
                 this.renderMarkdown(previewContent, content);
                 break;
-                
+
+            case '.mmd':
+                this.renderMermaid(previewContent, content);
+                break;
+
             case '.json':
                 this.renderJSON(previewContent, content);
                 break;
@@ -304,17 +317,63 @@ class QuickViewApp {
         `;
     }
 
+    renderMermaid(container, content) {
+        const mermaidDiv = document.createElement('div');
+        mermaidDiv.className = 'mermaid';
+        mermaidDiv.textContent = content.trim();
+
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'padding: 20px; background: white; display: flex; justify-content: center; align-items: flex-start; min-height: 100%; overflow: auto;';
+        wrapper.appendChild(mermaidDiv);
+
+        container.innerHTML = '';
+        container.appendChild(wrapper);
+
+        if (window.mermaid) {
+            mermaid.run({ nodes: [mermaidDiv] }).catch(err => {
+                mermaidDiv.textContent = '';
+                mermaidDiv.innerHTML = `<div class="error">Mermaid render error: ${this.escapeHtml(err.message)}</div>`;
+            });
+        }
+    }
+
     renderMarkdown(container, content) {
-        // Simple markdown rendering (would use marked.js in production)
-        const html = content
+        // Extract mermaid code blocks and replace with placeholders
+        const mermaidBlocks = [];
+        const withPlaceholders = content.replace(/```mermaid\n([\s\S]*?)```/g, (_, code) => {
+            const idx = mermaidBlocks.length;
+            mermaidBlocks.push(code.trim());
+            return `MERMAID_PLACEHOLDER_${idx}`;
+        });
+
+        // Basic markdown rendering
+        let html = withPlaceholders
             .replace(/^# (.*$)/gim, '<h1>$1</h1>')
             .replace(/^## (.*$)/gim, '<h2>$1</h2>')
             .replace(/^### (.*$)/gim, '<h3>$1</h3>')
             .replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>')
             .replace(/\*(.*)\*/gim, '<em>$1</em>')
             .replace(/\n/gim, '<br>');
-            
+
+        // Replace placeholders with mermaid div stubs
+        mermaidBlocks.forEach((_, idx) => {
+            html = html.replace(`MERMAID_PLACEHOLDER_${idx}`, `<div class="mermaid" data-mermaid-idx="${idx}"></div>`);
+        });
+
         container.innerHTML = `<div style="padding: 20px; color: #333;">${html}</div>`;
+
+        // Populate and render each mermaid block
+        if (window.mermaid && mermaidBlocks.length > 0) {
+            const nodes = Array.from(container.querySelectorAll('[data-mermaid-idx]')).map(el => {
+                el.textContent = mermaidBlocks[parseInt(el.dataset.mermaidIdx, 10)];
+                return el;
+            });
+            mermaid.run({ nodes }).catch(err => {
+                nodes.forEach(el => {
+                    el.innerHTML = `<div class="error">Mermaid render error: ${this.escapeHtml(err.message)}</div>`;
+                });
+            });
+        }
     }
 
     renderJSON(container, content) {

--- a/quickview-tool/public/index.html
+++ b/quickview-tool/public/index.html
@@ -62,6 +62,7 @@
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-background text-foreground h-screen overflow-hidden font-sans">
@@ -105,6 +106,7 @@
                                         <li class="text-sm text-gray-600">🎨 SVG Graphics</li>
                                         <li class="text-sm text-gray-600">📝 Markdown</li>
                                         <li class="text-sm text-gray-600">📊 JSON/YAML</li>
+                                        <li class="text-sm text-gray-600">🔀 Mermaid Diagrams</li>
                                     </ul>
                                 </div>
                             </div>

--- a/quickview-tool/server.js
+++ b/quickview-tool/server.js
@@ -44,7 +44,7 @@ class QuickViewServer {
       }
       
       // Security: Basic file type restrictions
-      const allowedExtensions = ['.html', '.jsx', '.js', '.py', '.css', '.json', '.md', '.svg', '.txt', '.xml', '.yaml', '.yml'];
+      const allowedExtensions = ['.html', '.jsx', '.js', '.py', '.css', '.json', '.md', '.svg', '.txt', '.xml', '.yaml', '.yml', '.mmd'];
       const ext = path.extname(filename).toLowerCase();
       if (ext && !allowedExtensions.includes(ext)) {
         return res.status(403).json({ error: 'File type not supported for security reasons' });


### PR DESCRIPTION
Adds Mermaid.js diagram rendering to the QuickView preview pane.

- Load Mermaid.js v11 from CDN
- Render standalone .mmd files as live SVG diagrams
- Detect and render ```mermaid code blocks inside Markdown previews
- Allow .mmd in the server file API

Closes #12

Generated with [Claude Code](https://claude.ai/code)